### PR TITLE
handle missing crypto artifact

### DIFF
--- a/src/main/java/pi2schema/crypto/materials/MissingCryptoMaterialsException.java
+++ b/src/main/java/pi2schema/crypto/materials/MissingCryptoMaterialsException.java
@@ -1,10 +1,10 @@
 package pi2schema.crypto.materials;
 
-public class DecryptingMaterialNotFoundException extends RuntimeException {
+public class MissingCryptoMaterialsException extends RuntimeException {
 
     private final String missingSubject;
 
-    public DecryptingMaterialNotFoundException(String missingSubject) {
+    public MissingCryptoMaterialsException(String missingSubject) {
         this.missingSubject = missingSubject;
     }
 


### PR DESCRIPTION
The mock of the kafka secret store miss lead the implementation to handle the materials not present in the keystore.

This pr still lets the CompletionException sneak out of the api / domain exception however this part still has to be reworked to the prover key version.