### PR TITLE
Fix large encryption data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,10 @@ dependencies {
     compile 'io.confluent:kafka-streams-protobuf-serde:5.5.1'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'
     testImplementation 'org.assertj:assertj-core:3.17.2'
+
+    testImplementation 'org.apache.commons:commons-lang3:3.11'
 
     testImplementation 'org.awaitility:awaitility:4.0.3'
 

--- a/src/main/java/pi2schema/crypto/LocalEncryptor.java
+++ b/src/main/java/pi2schema/crypto/LocalEncryptor.java
@@ -27,8 +27,7 @@ public class LocalEncryptor implements Encryptor {
     private final BiFunction<Cipher, byte[], CompletableFuture<byte[]>> encrypt =
             (Cipher c, byte[] bytes) -> CompletableFuture.supplyAsync(() -> {
                 try {
-                    c.update(bytes);
-                    return c.doFinal();
+                    return c.doFinal(bytes);
                 } catch (IllegalBlockSizeException | BadPaddingException e) {
                     throw new RuntimeException(e);
                 }

--- a/src/test/java/pi2schema/crypto/LocalCryptoTest.java
+++ b/src/test/java/pi2schema/crypto/LocalCryptoTest.java
@@ -1,6 +1,11 @@
 package pi2schema.crypto;
 
-import org.junit.jupiter.api.Test;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import pi2schema.crypto.materials.SymmetricMaterial;
 import pi2schema.crypto.providers.DecryptingMaterialsProvider;
 import pi2schema.crypto.providers.EncryptingMaterialsProvider;
@@ -10,16 +15,35 @@ import javax.crypto.SecretKey;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LocalCryptoTest {
 
-    @Test
-    void encrypt() throws NoSuchAlgorithmException, ExecutionException, InterruptedException {
+    static class RandomMultipleSizeStringArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return Stream.of(
+                    Arguments.of(RandomStringUtils.random(8)),
+                    Arguments.of(RandomStringUtils.random(24)),
+                    Arguments.of(RandomStringUtils.random(56)),
+                    Arguments.of(RandomStringUtils.random(120)),
+                    Arguments.of(RandomStringUtils.random(248)),
+                    Arguments.of(RandomStringUtils.random(1_116)),
+                    Arguments.of(RandomStringUtils.random(50_000))
+            );
+        }
+
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(RandomMultipleSizeStringArgumentsProvider.class)
+    void encrypt(String text) throws NoSuchAlgorithmException, ExecutionException, InterruptedException {
 
         //given
-        byte[] toBeEncrypted = "toBeEncrypted".getBytes();
+        byte[] toBeEncrypted = text.getBytes();
 
         SecretKey secretKey = KeyGen.aes256().generateKey();
 


### PR DESCRIPTION
The cipher update was misused. It is intended to do a multi part encryption. It would make sense the use when working with InputStreams or BufferStreams, however, protobuf has all the bytes in memory already, so for the moment it is going to be simple to do a one stage encryption.

The encryption function could be replaced to something withing the cipher itself now, as it is basically duplicated.

However there is a bunch more of work in order to make the encryption safer, including Wrapped keys/assymetric encryption or even simple hmac to guarantee authenticity. Both will extend the function code.