### PR TITLE
Kafka serializer configure

### DIFF
--- a/src/main/java/pi2schema/crypto/providers/DecryptingMaterialsProvider.java
+++ b/src/main/java/pi2schema/crypto/providers/DecryptingMaterialsProvider.java
@@ -1,14 +1,15 @@
 package pi2schema.crypto.providers;
 
-import pi2schema.crypto.materials.DecryptingMaterial;
 import org.jetbrains.annotations.NotNull;
 import pi2schema.crypto.materials.SymmetricMaterial;
 
+import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
-public interface DecryptingMaterialsProvider {
+public interface DecryptingMaterialsProvider extends Closeable {
 
     CompletableFuture<SymmetricMaterial> decryptionKeysFor(@NotNull String subjectId);
 
-
+    @Override
+    default void close() { }
 }

--- a/src/main/java/pi2schema/crypto/providers/EncryptingMaterialsProvider.java
+++ b/src/main/java/pi2schema/crypto/providers/EncryptingMaterialsProvider.java
@@ -1,12 +1,15 @@
 package pi2schema.crypto.providers;
 
-import pi2schema.crypto.materials.EncryptingMaterial;
 import org.jetbrains.annotations.NotNull;
 import pi2schema.crypto.materials.SymmetricMaterial;
 
+import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
-public interface EncryptingMaterialsProvider {
+public interface EncryptingMaterialsProvider extends Closeable {
 
     CompletableFuture<SymmetricMaterial> encryptionKeysFor(@NotNull String subjectId);
+
+    @Override
+    default void close() { }
 }

--- a/src/main/java/pi2schema/crypto/providers/inmemorykms/InMemoryKms.java
+++ b/src/main/java/pi2schema/crypto/providers/inmemorykms/InMemoryKms.java
@@ -40,4 +40,7 @@ public class InMemoryKms implements EncryptingMaterialsProvider, DecryptingMater
     public CompletableFuture<SymmetricMaterial> decryptionKeysFor(@NotNull String subjectId) {
         return CompletableFuture.completedFuture(keyStore.get(subjectId));
     }
+
+    @Override
+    public void close() { }
 }

--- a/src/main/java/pi2schema/crypto/providers/inmemorykms/InMemoryKms.java
+++ b/src/main/java/pi2schema/crypto/providers/inmemorykms/InMemoryKms.java
@@ -7,7 +7,6 @@ import pi2schema.crypto.providers.EncryptingMaterialsProvider;
 import pi2schema.crypto.support.KeyGen;
 
 import javax.crypto.KeyGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -22,7 +21,7 @@ public class InMemoryKms implements EncryptingMaterialsProvider, DecryptingMater
 
     private final Map<String, SymmetricMaterial> keyStore = new HashMap<>();
 
-    public InMemoryKms() throws NoSuchAlgorithmException {
+    public InMemoryKms() {
         this(KeyGen.aes256());
     }
 

--- a/src/main/java/pi2schema/crypto/providers/kafkakms/KafkaSecretKeyStore.java
+++ b/src/main/java/pi2schema/crypto/providers/kafkakms/KafkaSecretKeyStore.java
@@ -13,6 +13,7 @@ import pi2schema.kms.KafkaProvider;
 import pi2schema.kms.KafkaProvider.*;
 
 import javax.crypto.KeyGenerator;
+import java.io.Closeable;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
@@ -28,7 +29,7 @@ import java.util.concurrent.TimeUnit;
  * - right to be forgotten
  * - avoid global store / partitioning aware?
  */
-public class KafkaSecretKeyStore implements AutoCloseable {
+public class KafkaSecretKeyStore implements Closeable {
 
     private static final Logger log = LoggerFactory.getLogger(KafkaSecretKeyStore.class);
 
@@ -40,10 +41,12 @@ public class KafkaSecretKeyStore implements AutoCloseable {
 
     private final KafkaProducer<Subject, Commands> commandProducer;
 
-    public KafkaSecretKeyStore(KeyGenerator keyGenerator, Map<String, Object> configs) {
+    public KafkaSecretKeyStore(KeyGenerator keyGenerator, Map<String, ?> configs) {
         this.keyGenerator = keyGenerator;
         this.config = new KafkaSecretKeyStoreConfig(configs);
-        this.commandProducer = new KafkaProducer<>(configs,
+        Properties producerConfig = new Properties();
+        producerConfig.putAll(configs);
+        this.commandProducer = new KafkaProducer<>(producerConfig,
                 config.topics().COMMANDS.keySerializer(),
                 config.topics().COMMANDS.valueSerializer()
         );

--- a/src/main/java/pi2schema/crypto/providers/kafkakms/MostRecentMaterialsProvider.java
+++ b/src/main/java/pi2schema/crypto/providers/kafkakms/MostRecentMaterialsProvider.java
@@ -49,4 +49,9 @@ public class MostRecentMaterialsProvider implements EncryptingMaterialsProvider,
 
         return new SymmetricMaterial(new SecretKeySpec(latestKey, latestVersion.getAlgorithm()));
     }
+
+    @Override
+    public void close() {
+        kafkaSecretKeyStore.close();
+    }
 }

--- a/src/main/java/pi2schema/crypto/support/KeyGen.java
+++ b/src/main/java/pi2schema/crypto/support/KeyGen.java
@@ -4,9 +4,15 @@ import javax.crypto.KeyGenerator;
 import java.security.NoSuchAlgorithmException;
 
 public final class KeyGen {
-    public static final KeyGenerator aes256() throws NoSuchAlgorithmException {
-        KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
-        keyGenerator.init(256);
-        return keyGenerator;
+
+    public static KeyGenerator aes256() {
+        try {
+            KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+            keyGenerator.init(256);
+            return keyGenerator;
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e); // wrap internal?
+        }
     }
+
 }

--- a/src/main/java/pi2schema/serialization/kafka/KafkaGdprAwareProtobufSerializer.java
+++ b/src/main/java/pi2schema/serialization/kafka/KafkaGdprAwareProtobufSerializer.java
@@ -1,13 +1,20 @@
 package pi2schema.serialization.kafka;
 
-import pi2schema.crypto.Encryptor;
 import com.google.protobuf.Message;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Serializer;
+import org.jetbrains.annotations.NotNull;
+import pi2schema.crypto.Encryptor;
+import pi2schema.crypto.LocalEncryptor;
+import pi2schema.crypto.providers.EncryptingMaterialsProvider;
+import pi2schema.crypto.providers.kafkakms.KafkaSecretKeyStore;
+import pi2schema.crypto.providers.kafkakms.MostRecentMaterialsProvider;
+import pi2schema.crypto.support.KeyGen;
 
+import java.io.IOException;
 import java.util.Map;
 
 public class KafkaGdprAwareProtobufSerializer<T extends Message> implements Serializer<T> {
@@ -16,10 +23,11 @@ public class KafkaGdprAwareProtobufSerializer<T extends Message> implements Seri
 
     private final KafkaProtobufSerializer<T> inner;
     private ProtobufEncryptionEngine<T> protobufEncryptionEngine;
+    private EncryptingMaterialsProvider materialsProvider;
 
     public KafkaGdprAwareProtobufSerializer() {
         this.inner = new KafkaProtobufSerializer<>();
-
+        this.protobufEncryptionEngine = new UnconfiguredSerializer();
     }
 
     KafkaGdprAwareProtobufSerializer(Encryptor encryptor,
@@ -33,6 +41,8 @@ public class KafkaGdprAwareProtobufSerializer<T extends Message> implements Seri
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {
         inner.configure(configs, isKey);
+        materialsProvider = new MostRecentMaterialsProvider(new KafkaSecretKeyStore(KeyGen.aes256(), configs));
+        protobufEncryptionEngine = new ProtobufEncryptionEngine<>(new LocalEncryptor(materialsProvider));
     }
 
     @Override
@@ -53,6 +63,18 @@ public class KafkaGdprAwareProtobufSerializer<T extends Message> implements Seri
 
     @Override
     public void close() {
+        materialsProvider.close();
         inner.close();
+    }
+
+    private class UnconfiguredSerializer extends ProtobufEncryptionEngine<T> {
+        public UnconfiguredSerializer() {
+            super(null);
+        }
+
+        @Override
+        public T encrypt(@NotNull T data) {
+            throw new UnconfiguredException();
+        }
     }
 }

--- a/src/main/java/pi2schema/serialization/kafka/UnconfiguredException.java
+++ b/src/main/java/pi2schema/serialization/kafka/UnconfiguredException.java
@@ -1,0 +1,12 @@
+package pi2schema.serialization.kafka;
+
+public class UnconfiguredException extends IllegalStateException{
+
+    @Override
+    public String getMessage() {
+        return "When using the empty constructor which is expected for the Serializer interface," +
+                "the configure method is mandatory to be called in this serializer. \n" +
+                "The configure call should be made automatically if the object is instantiated by kafka." +
+                "Case the object is being created manually, please ensure the call of .configure before its use";
+    }
+}

--- a/src/test/java/pi2schema/crypto/providers/inmemorykms/InMemoryKmsTest.java
+++ b/src/test/java/pi2schema/crypto/providers/inmemorykms/InMemoryKmsTest.java
@@ -1,6 +1,5 @@
 package pi2schema.crypto.providers.inmemorykms;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import pi2schema.crypto.materials.DecryptingMaterial;
 import pi2schema.crypto.materials.EncryptingMaterial;
@@ -9,29 +8,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class InMemoryKmsTest {
 
-    private InMemoryKms kms;
-
-    @BeforeEach
-    void setUp() {
-        kms = new InMemoryKms();
-    }
-
     @Test
     void encryptionKeysFor() {
-        EncryptingMaterial aSubject = kms.encryptionKeysFor("aSubject").join();
+        try (InMemoryKms kms = new InMemoryKms()) {
+            EncryptingMaterial aSubject = kms.encryptionKeysFor("aSubject").join();
 
-        assertThat(aSubject).isNotNull();
-        assertThat(aSubject.getEncryptionKey()).isNotNull();
+            assertThat(aSubject).isNotNull();
+            assertThat(aSubject.getEncryptionKey()).isNotNull();
 
-        EncryptingMaterial sameEncryptingMaterial = kms.encryptionKeysFor("aSubject").join();
-        assertThat(sameEncryptingMaterial).isEqualTo(aSubject);
+            EncryptingMaterial sameEncryptingMaterial = kms.encryptionKeysFor("aSubject").join();
+            assertThat(sameEncryptingMaterial).isEqualTo(aSubject);
+        }
     }
 
     @Test
     void decryptionKeysFor() {
-        EncryptingMaterial aSubject = kms.encryptionKeysFor("aSubject").join();
-        DecryptingMaterial aSubjectRetrieved = kms.decryptionKeysFor("aSubject").join();
+        try (InMemoryKms kms = new InMemoryKms()) {
+            EncryptingMaterial aSubject = kms.encryptionKeysFor("aSubject").join();
+            DecryptingMaterial aSubjectRetrieved = kms.decryptionKeysFor("aSubject").join();
 
-        assertThat(aSubject).isEqualTo(aSubjectRetrieved);
+            assertThat(aSubject).isEqualTo(aSubjectRetrieved);
+        }
     }
 }

--- a/src/test/java/pi2schema/crypto/providers/inmemorykms/InMemoryKmsTest.java
+++ b/src/test/java/pi2schema/crypto/providers/inmemorykms/InMemoryKmsTest.java
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.Test;
 import pi2schema.crypto.materials.DecryptingMaterial;
 import pi2schema.crypto.materials.EncryptingMaterial;
 
-import java.security.NoSuchAlgorithmException;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 class InMemoryKmsTest {
@@ -14,7 +12,7 @@ class InMemoryKmsTest {
     private InMemoryKms kms;
 
     @BeforeEach
-    void setUp() throws NoSuchAlgorithmException {
+    void setUp() {
         kms = new InMemoryKms();
     }
 

--- a/src/test/java/pi2schema/crypto/providers/kafkakms/KafkaSecretKeyStoreTest.java
+++ b/src/test/java/pi2schema/crypto/providers/kafkakms/KafkaSecretKeyStoreTest.java
@@ -15,7 +15,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import pi2schema.crypto.support.KeyGen;
 import pi2schema.kms.KafkaProvider.SubjectCryptographicMaterialAggregate;
 
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -34,7 +33,7 @@ class KafkaSecretKeyStoreTest {
     private KafkaSecretKeyStore store;
 
     @BeforeEach
-    void setUp() throws NoSuchAlgorithmException {
+    void setUp() {
 
         kafka.start();
 

--- a/src/test/java/pi2schema/crypto/providers/kafkakms/KafkaSecretKeyStoreTest.java
+++ b/src/test/java/pi2schema/crypto/providers/kafkakms/KafkaSecretKeyStoreTest.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static pi2schema.crypto.providers.kafkakms.KafkaTestUtils.createTopics;
 
 @Testcontainers
 class KafkaSecretKeyStoreTest {
@@ -93,17 +94,5 @@ class KafkaSecretKeyStoreTest {
         SubjectCryptographicMaterialAggregate retrieveOrCreateSecond = store.retrieveOrCreateCryptoMaterialsFor(subject).join();
 
         assertThat(firstMaterials).isEqualTo(retrieveOrCreateSecond);
-    }
-
-
-    private static void createTopics(Map<String, Object> configs, String... topics) {
-        List<NewTopic> newTopics =
-                Arrays.stream(topics)
-                        .map(topic -> new NewTopic(topic, 1, (short) 1))
-                        .collect(Collectors.toList());
-
-        try (AdminClient admin = AdminClient.create(configs)) {
-            admin.createTopics(newTopics);
-        }
     }
 }

--- a/src/test/java/pi2schema/crypto/providers/kafkakms/KafkaTestUtils.java
+++ b/src/test/java/pi2schema/crypto/providers/kafkakms/KafkaTestUtils.java
@@ -1,0 +1,26 @@
+package pi2schema.crypto.providers.kafkakms;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class KafkaTestUtils {
+
+
+    public static void createTopics(Map<String, Object> configs, String... topics) {
+        List<NewTopic> newTopics =
+                Arrays.stream(topics)
+                        .map(topic -> new NewTopic(topic, 1, (short) 1))
+                        .collect(Collectors.toList());
+
+        try (AdminClient admin = AdminClient.create(configs)) {
+            admin.createTopics(newTopics);
+        }
+    }
+
+
+}

--- a/src/test/java/pi2schema/serialization/kafka/KafkaGdprAwareProtobufIntegrationTest.java
+++ b/src/test/java/pi2schema/serialization/kafka/KafkaGdprAwareProtobufIntegrationTest.java
@@ -1,0 +1,143 @@
+package pi2schema.serialization.kafka;
+
+import com.acme.FarmerRegisteredEventFixture;
+import com.acme.FarmerRegisteredEventOuterClass;
+import com.acme.FarmerRegisteredEventOuterClass.ContactInfo;
+import com.acme.FarmerRegisteredEventOuterClass.FarmerRegisteredEvent;
+import com.acme.FruitFixture;
+import com.acme.FruitOuterClass.Fruit;
+import com.google.protobuf.Message;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerConfig;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import pi2schema.crypto.materials.MissingCryptoMaterialsException;
+import pi2schema.crypto.providers.kafkakms.KafkaSecretKeyStoreConfig;
+import pi2schema.kms.KafkaProvider;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+
+import static com.acme.FarmerRegisteredEventOuterClass.FarmerRegisteredEvent.PersonalDataCase.ENCRYPTEDPERSONALDATA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static pi2schema.crypto.providers.kafkakms.KafkaTestUtils.createTopics;
+
+@Testcontainers
+class KafkaGdprAwareProtobufIntegrationTest {
+
+    @Rule
+    public KafkaContainer kafka = new KafkaContainer().withNetwork(Network.SHARED);
+
+    private GenericContainer schemaRegistry;
+
+    private final Map<String, Object> configs;
+
+    private Fruit waterMelon = FruitFixture.waterMelon().build();
+
+    KafkaGdprAwareProtobufIntegrationTest() {
+
+        kafka.start();
+
+        schemaRegistry = new GenericContainer("confluentinc/cp-schema-registry:5.5.1")
+                .withNetwork(Network.SHARED)
+                .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://" + kafka.getNetworkAliases().get(0) + ":9092")
+                .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+                .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:8081")
+                .withExposedPorts(8081);
+
+        schemaRegistry.start();
+
+        String schemaRegistryUrl = "http://" + schemaRegistry.getContainerIpAddress() +
+                ":" + schemaRegistry.getMappedPort(8081);
+
+        HashMap<String, Object> configuring = new HashMap<>();
+        configuring.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        configuring.put(KafkaProtobufSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl);
+        configuring.put(KafkaProtobufSerializerConfig.AUTO_REGISTER_SCHEMAS, true);
+        configuring.put(KafkaProtobufDeserializerConfig.DERIVE_TYPE_CONFIG, true);
+
+        this.configs = Collections.unmodifiableMap(configuring);
+
+        createTopics(configs, "pi2schema.kms.commands");
+    }
+
+    @Test
+    void serializeShouldFailWithIllegalStateExceptionCaseTheConfigureMethodIsNotCalled() {
+
+        //Default constructor is required by kafka for scenarios of configuration like key.serializer which the kafka
+        // client uses reflection to instantiate and Configurable to initiate.
+        KafkaGdprAwareProtobufSerializer<Fruit> serializer = new KafkaGdprAwareProtobufSerializer<>();
+        UnconfiguredException unconfiguredException = assertThrows(UnconfiguredException.class, () ->
+                serializer.serialize("", waterMelon));
+
+        assertThat(unconfiguredException).hasMessageContaining("configure method");
+    }
+
+    @Test
+    void deserializeShouldFailWithIllegalStateExceptionCaseTheConfigureMethodIsNotCalled() {
+
+        KafkaGdprAwareProtobufDeserializer<Fruit> deserializer = new KafkaGdprAwareProtobufDeserializer<>();
+        UnconfiguredException unconfiguredException = assertThrows(UnconfiguredException.class, () ->
+                deserializer.deserialize("", new byte[0]));
+
+        assertThat(unconfiguredException).hasMessageContaining("configure method");
+    }
+
+    @Test
+    void configuredUsingKafkaMaterialsProvider() {
+        FarmerRegisteredEvent eventWithPersonalData = FarmerRegisteredEventFixture.johnDoe().build();
+
+        // serialization with personal data to be encrypted
+        KafkaGdprAwareProtobufSerializer<FarmerRegisteredEvent> serializer = new KafkaGdprAwareProtobufSerializer<>();
+        serializer.configure(configs, false);
+        byte[] serializedWithCryptoData = serializer.serialize("", eventWithPersonalData);
+
+
+        // standard deserialization, should be compatible and provide a encrypted value
+        try (KafkaProtobufDeserializer<FarmerRegisteredEvent> standardDeserializer = new KafkaProtobufDeserializer<>()) {
+            standardDeserializer.configure(configs, false);
+            FarmerRegisteredEvent deserializedEncrypted = standardDeserializer.deserialize("", serializedWithCryptoData);
+
+            assertThat(deserializedEncrypted).isNotNull();
+            assertThat(deserializedEncrypted.getPersonalDataCase()).isEqualByComparingTo(ENCRYPTEDPERSONALDATA);
+            assertThat(deserializedEncrypted.getContactInfo()).isEqualTo(ContactInfo.getDefaultInstance());
+            assertThat(eventWithPersonalData).isNotEqualTo(deserializedEncrypted);
+        }
+
+        try (KafkaGdprAwareProtobufDeserializer<FarmerRegisteredEvent> deserializer = new KafkaGdprAwareProtobufDeserializer<>()) {
+            deserializer.configure(configs, false);
+
+            await().atMost(Duration.ofSeconds(600)).untilAsserted(
+                    () -> {
+                        try {
+                            FarmerRegisteredEvent decrypted = deserializer.deserialize("", serializedWithCryptoData);
+                            assertThat(eventWithPersonalData).isEqualTo(decrypted);
+                        } catch (CompletionException e) {
+                            // failed exception in order to be retried by the awaitability.
+                            if (e.getCause() instanceof MissingCryptoMaterialsException) {
+                                fail(e);
+                            }
+                            throw e;
+                        }
+                    }
+            );
+        } finally {
+            //also close the initial serializer
+            serializer.close();
+        }
+
+    }
+}

--- a/src/test/proto/farmer_registered_event.proto
+++ b/src/test/proto/farmer_registered_event.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package com.acme;
+option java_outer_classname = "FarmerRegisteredEventOuterClass";
 
 import 'google/protobuf/timestamp.proto';
 


### PR DESCRIPTION
Configured the kafkakms as default of the serializer/deserializer and related end to end test using testcontainers.

The kms/materialsprovider as well as the encryption strategy should be configurable, provided by a factory based on the provided configure(map configuration). Will add this once we actually implement other kms.

The current decryptor is still sync, so the consumer has a strong chance to try to process  the message before the key is available. The consumer should rely on a retry topic in order to guarantee resilience/not loss of data.

closes #5 