### PR TITLE
upgrade to java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
 
     - name: Setup build cache
       uses: actions/cache@v2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout latest code
         uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Setup build cache
         uses: actions/cache@v2

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ allprojects {
 subprojects {
 
     java {
-        sourceCompatibility(JavaVersion.VERSION_1_8)
-        targetCompatibility(JavaVersion.VERSION_1_8)
+        sourceCompatibility(JavaVersion.VERSION_11)
+        targetCompatibility(JavaVersion.VERSION_11)
     }
 
     dependencies {


### PR DESCRIPTION
Simply enable java 11 for the project.
No code changes at this moment.

Recently while working with CompletableFutures, we suffered with limitations from java 8.

Considering that the code (or at least some part) tends to rely on java crypto architecture jca, it is extremely important to rely on a maintained up to date jdk.

closes #42 