### PR TITLE
Replace byte[]  by ByteBuffers on crypto interfaces

### DIFF
--- a/crypto-spi/src/main/java/pi2schema/crypto/Decryptor.java
+++ b/crypto-spi/src/main/java/pi2schema/crypto/Decryptor.java
@@ -1,8 +1,9 @@
 package pi2schema.crypto;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
 public interface Decryptor {
 
-    CompletableFuture<byte[]> decrypt(String key, EncryptedData data);
+    CompletableFuture<ByteBuffer> decrypt(String key, EncryptedData data);
 }

--- a/crypto-spi/src/main/java/pi2schema/crypto/EncryptedData.java
+++ b/crypto-spi/src/main/java/pi2schema/crypto/EncryptedData.java
@@ -1,14 +1,15 @@
 package pi2schema.crypto;
 
 import javax.crypto.spec.IvParameterSpec;
+import java.nio.ByteBuffer;
 
 public final class EncryptedData {
 
-    private final byte[] data;
+    private final ByteBuffer data;
     private final String usedTransformation;
     private final IvParameterSpec initializationVector;
 
-    public EncryptedData(byte[] data, String usedTransformation, IvParameterSpec initializationVector) {
+    public EncryptedData(ByteBuffer data, String usedTransformation, IvParameterSpec initializationVector) {
         this.data = data;
         this.usedTransformation = usedTransformation;
         this.initializationVector = initializationVector;
@@ -17,7 +18,7 @@ public final class EncryptedData {
     /**
      * @return The encrypted/ciphered data
      */
-    public byte[] data() {
+    public ByteBuffer data() {
         return data;
     }
 

--- a/crypto-spi/src/main/java/pi2schema/crypto/Encryptor.java
+++ b/crypto-spi/src/main/java/pi2schema/crypto/Encryptor.java
@@ -1,8 +1,9 @@
 package pi2schema.crypto;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
 public interface Encryptor {
 
-    CompletableFuture<EncryptedData> encrypt(String subjectId, byte[] data);
+    CompletableFuture<EncryptedData> encrypt(String subjectId, ByteBuffer data);
 }

--- a/crypto-spi/src/main/java/pi2schema/crypto/LocalDecryptor.java
+++ b/crypto-spi/src/main/java/pi2schema/crypto/LocalDecryptor.java
@@ -3,6 +3,7 @@ package pi2schema.crypto;
 import pi2schema.crypto.materials.SymmetricMaterial;
 import pi2schema.crypto.providers.DecryptingMaterialsProvider;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
 public class LocalDecryptor implements Decryptor {
@@ -14,7 +15,7 @@ public class LocalDecryptor implements Decryptor {
     }
 
     @Override
-    public CompletableFuture<byte[]> decrypt(String key, EncryptedData encryptedData) {
+    public CompletableFuture<ByteBuffer> decrypt(String key, EncryptedData encryptedData) {
         return provider.decryptionKeysFor(key)
                 .thenApply(SymmetricMaterial::getDecryptionKey)
                 .thenCompose(decryptionKey ->

--- a/crypto-spi/src/main/java/pi2schema/crypto/LocalEncryptor.java
+++ b/crypto-spi/src/main/java/pi2schema/crypto/LocalEncryptor.java
@@ -4,6 +4,7 @@ import pi2schema.crypto.materials.SymmetricMaterial;
 import pi2schema.crypto.providers.EncryptingMaterialsProvider;
 
 import javax.crypto.spec.IvParameterSpec;
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -25,7 +26,7 @@ public class LocalEncryptor implements Encryptor {
     }
 
     @Override
-    public CompletableFuture<EncryptedData> encrypt(String subjectId, byte[] data) {
+    public CompletableFuture<EncryptedData> encrypt(String subjectId, ByteBuffer data) {
         return provider
                 .encryptionKeysFor(subjectId)
                 .thenApply(SymmetricMaterial::getEncryptionKey)

--- a/schema-providers-protobuf/src/test/java/pi2schema/schema/providers/protobuf/personaldata/OneOfPersonalDataFieldDefinitionTest.java
+++ b/schema-providers-protobuf/src/test/java/pi2schema/schema/providers/protobuf/personaldata/OneOfPersonalDataFieldDefinitionTest.java
@@ -122,7 +122,7 @@ class OneOfPersonalDataFieldDefinitionTest {
         var personalDataFieldDef = FarmerRegisteredEventFixture.personalDataFieldDefinition();
 
         Decryptor decryptor = (key, data) ->
-                CompletableFuture.completedFuture(decrypted.toByteArray());
+                CompletableFuture.completedFuture(decrypted.asReadOnlyByteBuffer());
 
         //when
         personalDataFieldDef.swapToDecrypted(decryptor, encryptedEvent);

--- a/schema-spi/src/main/java/pi2schema/schema/personaldata/PersonalDataValueProvider.java
+++ b/schema-spi/src/main/java/pi2schema/schema/personaldata/PersonalDataValueProvider.java
@@ -1,6 +1,8 @@
 package pi2schema.schema.personaldata;
 
+import java.nio.ByteBuffer;
+
 public interface PersonalDataValueProvider<T> {
 
-    byte[] valueFrom(T instance);
+    ByteBuffer valueFrom(T instance);
 }

--- a/serialization-kafka-protobuf/src/test/java/pi2schema/serialization/kafka/KafkaGdprAwareProtobufDeserializerTest.java
+++ b/serialization-kafka-protobuf/src/test/java/pi2schema/serialization/kafka/KafkaGdprAwareProtobufDeserializerTest.java
@@ -33,10 +33,9 @@ public class KafkaGdprAwareProtobufDeserializerTest {
             CompletableFuture.completedFuture(encryptedData.data());
 
     public KafkaGdprAwareProtobufDeserializerTest() {
-        var initial = new HashMap<String, Object>();
-        initial.put(KafkaProtobufSerializerConfig.AUTO_REGISTER_SCHEMAS, true);
-        initial.put(KafkaProtobufSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
-        this.configs = Collections.unmodifiableMap(initial);
+        this.configs = Map.of(
+                KafkaProtobufSerializerConfig.AUTO_REGISTER_SCHEMAS, true,
+                KafkaProtobufSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
         this.serializer = new KafkaProtobufSerializer(schemaRegistry, configs);
     }
 
@@ -84,7 +83,7 @@ public class KafkaGdprAwareProtobufDeserializerTest {
                 .build();
 
         Decryptor decryptor = (subj, data) ->
-                CompletableFuture.completedFuture(decrypted.toByteArray());
+                CompletableFuture.completedFuture(decrypted.asReadOnlyByteBuffer());
 
         var deserializer = new KafkaGdprAwareProtobufDeserializer<>(
                 decryptor,


### PR DESCRIPTION
byte[] are mutable which can be the cause of multiple vulnerabilities defined in the book http://cryptobook.us.

Also provides a nice interface to interact with other libraries as protobuf.