### PR TITLE
Run all the tests even if a subproject test fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew --continue build
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
By using --continue the build still will fail, but will provide an overview of all the project rather than only a subproject.

Since we migrated to multi module project, it became more visible that if one Test fail, the downstream projects are not built.

This was clear for example, while refactoring the crypto spi from byte[] to bytebuffer which caused extra buffer be null and broke crypto-spi-kafka but also serializers. Of course running locally at this stage is easy to add run with the continue however it would be interesting to keep the local flow closer to the build pipeline.