### PR TITLE
chore: introduce spotbugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'net.researchgate.release' version '2.8.1'
+    id "com.github.spotbugs" version "4.5.0" apply false
 }
 
 allprojects {
@@ -7,6 +8,7 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
     apply plugin: 'jacoco'
+    apply plugin: 'com.github.spotbugs'
     apply plugin: 'maven-publish'
 
     group 'com.github.pi2schema'
@@ -46,6 +48,11 @@ subprojects {
         testLogging {
             events "passed", "skipped", "failed"
         }
+    }
+
+    // do not run spot bugs on test for the time being
+    spotbugsTest {
+        enabled false
     }
 
 	publishing {

--- a/crypto-providers-kafkakms/build.gradle
+++ b/crypto-providers-kafkakms/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
 }
 
-
 plugins {
     id 'com.google.protobuf' version '0.8.13'
 }
@@ -15,7 +14,6 @@ protobuf {
     }
 }
 
-
 sourceSets {
     main {
         proto {
@@ -25,7 +23,6 @@ sourceSets {
     }
 }
 
-
 idea {
     module {
         // proto files and generated Java files are automatically added as source dirs.
@@ -34,6 +31,10 @@ idea {
     }
 }
 
+// remove auto generated proto classes used for the serialization persistence.
+spotbugs {
+    onlyAnalyze = ['pi2schema.crypto.providers.kafkakms.*']
+}
 
 dependencies {
 

--- a/schema-providers-protobuf/build.gradle
+++ b/schema-providers-protobuf/build.gradle
@@ -4,9 +4,7 @@ buildscript {
     }
 }
 
-
 plugins {
-    id 'java'
     id 'java-test-fixtures'
     id 'com.google.protobuf' version '0.8.13'
 }
@@ -17,13 +15,17 @@ protobuf {
     }
 }
 
-
 idea {
     module {
         // proto files and generated Java files are automatically added as source dirs.
         // If you have additional sources, add them here:
         sourceDirs += file("/generated/source/proto")
     }
+}
+
+// remove auto generated proto classes used for the serialization persistence.
+spotbugs {
+    onlyAnalyze = ['pi2schema.schema.providers.protobuf.*']
 }
 
 dependencies {


### PR DESCRIPTION
Spotbugs seems to be one of the first to support jspecify which seems to be promising.

Also with really active maintenance and sounds like a replacement to findbugs.

The test source code is kept on the side for the time being as there is quite some auto generated code that has to be removed from the inspection as well as valid points to be worked on, however would like to focus on the Nullability.

There will be following commits/pr introducing jspecify and defining default nullability .