### PR TITLE
Centralize Confluent library versions in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,8 @@ ext {
             protobufJava: '3.25.1',
             protoc: '3.25.1',
             protobufGradlePlugin: protobufGradlePluginVersion,
-            junitJupiter: '5.10.5'
+            junitJupiter: '5.10.5',
+            confluent: '7.5.8'
     ]
 }
 

--- a/crypto-providers-kafkakms/build.gradle
+++ b/crypto-providers-kafkakms/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation project(':crypto-spi')
 
     implementation 'org.apache.kafka:kafka-streams:3.2.3'
-    implementation 'io.confluent:kafka-streams-protobuf-serde:7.5.9'
+    implementation "io.confluent:kafka-streams-protobuf-serde:${rootProject.ext.versions.confluent}"
 
     implementation "com.google.protobuf:protobuf-java:${rootProject.ext.versions.protobufJava}"
 

--- a/examples/springboot-avro-kafkakms/build.gradle
+++ b/examples/springboot-avro-kafkakms/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	implementation(project(":schema-providers-avro"))
 	implementation(project(":serialization-adapters-kafka"))
 
-	implementation("io.confluent:kafka-avro-serializer:7.5.9")
+	implementation("io.confluent:kafka-avro-serializer:${rootProject.ext.versions.confluent}")
 	implementation 'org.apache.avro:avro:1.11.4'
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/examples/springboot-protobuf-kafkakms/build.gradle
+++ b/examples/springboot-protobuf-kafkakms/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 	implementation("com.google.protobuf:protobuf-java:${rootProject.ext.versions.protobufJava}")
 
-	implementation("io.confluent:kafka-protobuf-serializer:7.5.9")
+	implementation("io.confluent:kafka-protobuf-serializer:7.5.8")
 
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/examples/springboot-protobuf-kafkakms/build.gradle
+++ b/examples/springboot-protobuf-kafkakms/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 	implementation("com.google.protobuf:protobuf-java:${rootProject.ext.versions.protobufJava}")
 
-	implementation("io.confluent:kafka-protobuf-serializer:7.5.8")
+	implementation("io.confluent:kafka-protobuf-serializer:${rootProject.ext.versions.confluent}")
 
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized the management of the Confluent dependency version for improved consistency across modules.
  * Updated build configuration to reference the shared Confluent version property instead of hardcoded versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->