### PR TITLE
Fix failing test due to storage not started

### DIFF
--- a/crypto-providers-kafkakms/src/main/java/pi2schema/crypto/providers/kafkakms/KafkaSecretKeyStore.java
+++ b/crypto-providers-kafkakms/src/main/java/pi2schema/crypto/providers/kafkakms/KafkaSecretKeyStore.java
@@ -68,6 +68,10 @@ public class KafkaSecretKeyStore implements Closeable {
                 );
     }
 
+    boolean isRunning() {
+        return streams.state().isRunningOrRebalancing();
+    }
+
     CompletableFuture<SubjectCryptographicMaterialAggregate> retrieveOrCreateCryptoMaterialsFor(
         @NotNull String subjectId
     ) {

--- a/crypto-providers-kafkakms/src/test/java/pi2schema/crypto/providers/kafkakms/KafkaSecretKeyStoreTest.java
+++ b/crypto-providers-kafkakms/src/test/java/pi2schema/crypto/providers/kafkakms/KafkaSecretKeyStoreTest.java
@@ -52,6 +52,8 @@ class KafkaSecretKeyStoreTest {
 
     @Test
     void getOrCreate() {
+        await().atMost(Duration.ofSeconds(20)).until(() -> store.isRunning());
+
         var subject = UUID.randomUUID().toString();
 
         // create


### PR DESCRIPTION
The Kafka streams storage startup time and sync time might take some seconds which could make the test fail in faster and especially over paralellized computing