### PR TITLE
Adopted Gradle Version Catalogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 .idea
 .gradle/
+.vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -1,41 +1,21 @@
-// Define the plugin version in buildscript
-buildscript {
-    ext {
-        protobufGradlePluginVersion = '0.9.4'
-    }
-}
-
-// Define centralized versions
 plugins {
-    id 'net.researchgate.release' version '3.0.2'
-    id "com.github.spotbugs" version "6.0.28" apply false
-    id "com.diffplug.spotless" version "6.23.3"
+    alias(libs.plugins.release)
+    alias(libs.plugins.spotbugs) apply false
+    alias(libs.plugins.spotless)
 
     //applied only in specific subprojects, yet important to define globally
-    id "org.jetbrains.kotlin.jvm" version '1.9.25' apply false
-    id "org.jetbrains.kotlin.plugin.spring" version '1.9.25' apply false
-    id "io.spring.dependency-management"  version "1.1.7" apply false
-    id "org.springframework.boot"  version "3.1.12"  apply false
-    id "com.github.davidmc24.gradle.plugin.avro" version "1.9.1" apply false
-    id "com.google.protobuf" version "0.9.5" apply false
-}
-
-// Define centralized versions
-ext {
-    versions = [
-            protobufJava: '3.25.1',
-            protoc: '3.25.1',
-            protobufGradlePlugin: protobufGradlePluginVersion,
-            junitJupiter: '5.10.5',
-            confluent: '7.5.8'
-    ]
+    alias(libs.plugins.kotlin.jvm) apply false
+    alias(libs.plugins.kotlin.spring) apply false
+    alias(libs.plugins.spring.dependency.management) apply false
+    alias(libs.plugins.spring.boot) apply false
+    alias(libs.plugins.avro) apply false
+    alias(libs.plugins.protobuf) apply false
 }
 
 allprojects {
 
     apply plugin: 'java'
     apply plugin: 'idea'
-//    apply plugin: 'jacoco'
     apply plugin: 'com.github.spotbugs'
     apply plugin: 'com.diffplug.spotless'
     apply plugin: 'maven-publish'
@@ -82,18 +62,11 @@ subprojects {
 
     dependencies {
 
-        implementation 'ch.qos.logback:logback-classic:1.4.14'
+        implementation libs.logback.classic
 
         // JUnit dependencies with centralized version
-        testImplementation "org.junit.jupiter:junit-jupiter:${versions.junitJupiter}"
-        testImplementation "org.junit.jupiter:junit-jupiter-params:${versions.junitJupiter}"
+        testImplementation libs.bundles.testing
         
-        testImplementation 'org.assertj:assertj-core:3.24.2'
-        testImplementation 'org.apache.commons:commons-lang3:3.14.0'
-        testImplementation 'org.awaitility:awaitility:4.2.2'
-        testImplementation 'org.mockito:mockito-core:5.8.0'
-        testImplementation "org.mockito:mockito-junit-jupiter:5.8.0"
-
     }
 
     test {

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ plugins {
     alias(libs.plugins.spotless)
 
     //applied only in specific subprojects, yet important to define globally
-    alias(libs.plugins.kotlin.jvm) apply false
-    alias(libs.plugins.kotlin.spring) apply false
-    alias(libs.plugins.spring.dependency.management) apply false
-    alias(libs.plugins.spring.boot) apply false
+    alias(exampleLibs.plugins.kotlin.jvm) apply false
+    alias(exampleLibs.plugins.kotlin.spring) apply false
+    alias(exampleLibs.plugins.spring.dependency.management) apply false
+    alias(exampleLibs.plugins.spring.boot) apply false
     alias(libs.plugins.avro) apply false
     alias(libs.plugins.protobuf) apply false
 }

--- a/crypto-providers-kafkakms/build.gradle
+++ b/crypto-providers-kafkakms/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
     dependencies {
-        classpath "com.google.protobuf:protobuf-gradle-plugin:${rootProject.ext.versions.protobufGradlePlugin}"
+        classpath libs.protobuf.gradle.plugin
     }
 }
 
 plugins {
-    id 'com.google.protobuf' version '0.9.5'
+    alias(libs.plugins.protobuf)
 }
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:${rootProject.ext.versions.protoc}"
+        artifact = "com.google.protobuf:protoc:${libs.versions.protoc.get()}"
     }
 }
 
@@ -40,14 +40,12 @@ dependencies {
 
     implementation project(':crypto-spi')
 
-    implementation 'org.apache.kafka:kafka-streams:3.2.3'
-    implementation "io.confluent:kafka-streams-protobuf-serde:${rootProject.ext.versions.confluent}"
+    implementation libs.kafka.streams
+    implementation libs.confluent.kafka.streams.protobuf.serde
 
-    implementation "com.google.protobuf:protobuf-java:${rootProject.ext.versions.protobufJava}"
+    implementation libs.protobuf.java
 
-    implementation 'org.awaitility:awaitility:4.2.2'
+    implementation libs.awaitility
 
-    testImplementation "org.testcontainers:testcontainers:1.20.6"
-    testImplementation "org.testcontainers:junit-jupiter:1.20.6"
-    testImplementation "org.testcontainers:redpanda:1.20.6"
+    testImplementation libs.bundles.testcontainers
 }

--- a/examples/libs.versions.toml
+++ b/examples/libs.versions.toml
@@ -1,0 +1,25 @@
+[versions]
+kotlin = "1.9.25"
+spring-dependency-management = "1.1.7"
+spring-boot = "3.1.12"
+reactor-kotlin-extensions = "1.2.3"
+kotlinx-coroutines-reactor = "1.8.1"
+
+[libraries]
+spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+spring-boot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers" }
+spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
+spring-kafka-test = { module = "org.springframework.kafka:spring-kafka-test" }
+reactor-kotlin-extensions = { module = "io.projectreactor.kotlin:reactor-kotlin-extensions", version.ref = "reactor-kotlin-extensions" }
+reactor-test = { module = "io.projectreactor:reactor-test" }
+kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinx-coroutines-reactor" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
+spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-dependency-management" }
+spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/examples/springboot-avro-kafkakms/build.gradle
+++ b/examples/springboot-avro-kafkakms/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-	alias(libs.plugins.spring.dependency.management)
-	alias(libs.plugins.spring.boot)
-	alias(libs.plugins.kotlin.jvm)
-	alias(libs.plugins.kotlin.spring)
+	alias(exampleLibs.plugins.spring.dependency.management)
+	alias(exampleLibs.plugins.spring.boot)
+	alias(exampleLibs.plugins.kotlin.jvm)
+	alias(exampleLibs.plugins.kotlin.spring)
 	alias(libs.plugins.avro)
 }
 
@@ -23,22 +23,22 @@ dependencies {
 
 	implementation libs.confluent.kafka.avro.serializer
 	implementation libs.avro
-	implementation libs.spring.boot.starter.webflux
-	implementation libs.jackson.module.kotlin
-	implementation libs.reactor.kotlin.extensions
+	implementation exampleLibs.spring.boot.starter.webflux
+	implementation exampleLibs.jackson.module.kotlin
+	implementation exampleLibs.reactor.kotlin.extensions
 	implementation libs.kafka.streams
-	implementation libs.kotlin.reflect
-	implementation libs.kotlin.stdlib.jdk8
-	implementation libs.kotlinx.coroutines.reactor
-	implementation libs.spring.kafka
+	implementation exampleLibs.kotlin.reflect
+	implementation exampleLibs.kotlin.stdlib.jdk8
+	implementation exampleLibs.kotlinx.coroutines.reactor
+	implementation exampleLibs.spring.kafka
 
-	testImplementation(libs.spring.boot.starter.test) {
+	testImplementation(exampleLibs.spring.boot.starter.test) {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
-	testImplementation libs.reactor.test
-	testImplementation libs.spring.kafka.test
+	testImplementation exampleLibs.reactor.test
+	testImplementation exampleLibs.spring.kafka.test
 
-	testImplementation libs.spring.boot.testcontainers
+	testImplementation exampleLibs.spring.boot.testcontainers
 
 	testImplementation libs.bundles.testcontainers
 }

--- a/examples/springboot-avro-kafkakms/build.gradle
+++ b/examples/springboot-avro-kafkakms/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-	id "io.spring.dependency-management"
-	id "org.springframework.boot"
-	id "org.jetbrains.kotlin.jvm"
-	id "org.jetbrains.kotlin.plugin.spring"
-	id "com.github.davidmc24.gradle.plugin.avro"
+	alias(libs.plugins.spring.dependency.management)
+	alias(libs.plugins.spring.boot)
+	alias(libs.plugins.kotlin.jvm)
+	alias(libs.plugins.kotlin.spring)
+	alias(libs.plugins.avro)
 }
 
 
@@ -21,28 +21,26 @@ dependencies {
 	implementation(project(":schema-providers-avro"))
 	implementation(project(":serialization-adapters-kafka"))
 
-	implementation("io.confluent:kafka-avro-serializer:${rootProject.ext.versions.confluent}")
-	implementation 'org.apache.avro:avro:1.11.4'
-	implementation("org.springframework.boot:spring-boot-starter-webflux")
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
-	implementation("org.apache.kafka:kafka-streams")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
-	implementation("org.springframework.kafka:spring-kafka")
+	implementation libs.confluent.kafka.avro.serializer
+	implementation libs.avro
+	implementation libs.spring.boot.starter.webflux
+	implementation libs.jackson.module.kotlin
+	implementation libs.reactor.kotlin.extensions
+	implementation libs.kafka.streams
+	implementation libs.kotlin.reflect
+	implementation libs.kotlin.stdlib.jdk8
+	implementation libs.kotlinx.coroutines.reactor
+	implementation libs.spring.kafka
 
-	testImplementation("org.springframework.boot:spring-boot-starter-test") {
+	testImplementation(libs.spring.boot.starter.test) {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
-	testImplementation("io.projectreactor:reactor-test")
-	testImplementation("org.springframework.kafka:spring-kafka-test")
+	testImplementation libs.reactor.test
+	testImplementation libs.spring.kafka.test
 
-	testImplementation("org.springframework.boot:spring-boot-testcontainers")
+	testImplementation libs.spring.boot.testcontainers
 
-	testImplementation("org.testcontainers:testcontainers:1.20.6")
-	testImplementation("org.testcontainers:junit-jupiter:1.20.6")
-	testImplementation ("org.testcontainers:redpanda:1.20.6")
+	testImplementation libs.bundles.testcontainers
 }
 
 

--- a/examples/springboot-protobuf-kafkakms/build.gradle
+++ b/examples/springboot-protobuf-kafkakms/build.gradle
@@ -6,10 +6,10 @@ buildscript {
 
 
 plugins {
-	alias(libs.plugins.spring.dependency.management)
-	alias(libs.plugins.spring.boot)
-	alias(libs.plugins.kotlin.jvm)
-	alias(libs.plugins.kotlin.spring)
+	alias(exampleLibs.plugins.spring.dependency.management)
+	alias(exampleLibs.plugins.spring.boot)
+	alias(exampleLibs.plugins.kotlin.jvm)
+	alias(exampleLibs.plugins.kotlin.spring)
 	alias(libs.plugins.protobuf)
 }
 
@@ -38,22 +38,22 @@ dependencies {
 
 	implementation libs.confluent.kafka.protobuf.serializer
 
-	implementation libs.spring.boot.starter.webflux
-	implementation libs.jackson.module.kotlin
-	implementation libs.reactor.kotlin.extensions
+	implementation exampleLibs.spring.boot.starter.webflux
+	implementation exampleLibs.jackson.module.kotlin
+	implementation exampleLibs.reactor.kotlin.extensions
 	implementation libs.kafka.streams
-	implementation libs.kotlin.reflect
-	implementation libs.kotlin.stdlib.jdk8
-	implementation libs.kotlinx.coroutines.reactor
-	implementation libs.spring.kafka
+	implementation exampleLibs.kotlin.reflect
+	implementation exampleLibs.kotlin.stdlib.jdk8
+	implementation exampleLibs.kotlinx.coroutines.reactor
+	implementation exampleLibs.spring.kafka
 
-	testImplementation(libs.spring.boot.starter.test) {
+	testImplementation(exampleLibs.spring.boot.starter.test) {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
-	testImplementation libs.reactor.test
-	testImplementation libs.spring.kafka.test
+	testImplementation exampleLibs.reactor.test
+	testImplementation exampleLibs.spring.kafka.test
 
-	testImplementation libs.spring.boot.testcontainers
+	testImplementation exampleLibs.spring.boot.testcontainers
 
 	testImplementation libs.bundles.testcontainers
 }

--- a/examples/springboot-protobuf-kafkakms/build.gradle
+++ b/examples/springboot-protobuf-kafkakms/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
 	dependencies {
-		classpath "com.google.protobuf:protobuf-gradle-plugin:${rootProject.ext.versions.protobufGradlePlugin}"
+		classpath libs.protobuf.gradle.plugin
 	}
 }
 
 
 plugins {
-	id "io.spring.dependency-management"
-	id "org.springframework.boot"
-	id "org.jetbrains.kotlin.jvm"
-	id "org.jetbrains.kotlin.plugin.spring"
-	id "com.google.protobuf"
+	alias(libs.plugins.spring.dependency.management)
+	alias(libs.plugins.spring.boot)
+	alias(libs.plugins.kotlin.jvm)
+	alias(libs.plugins.kotlin.spring)
+	alias(libs.plugins.protobuf)
 }
 
 group = "com.acme"
@@ -34,30 +34,28 @@ dependencies {
 	implementation(project(":schema-providers-protobuf"))
 	implementation(project(":serialization-adapters-kafka"))
 
-	implementation("com.google.protobuf:protobuf-java:${rootProject.ext.versions.protobufJava}")
+	implementation libs.protobuf.java
 
-	implementation("io.confluent:kafka-protobuf-serializer:${rootProject.ext.versions.confluent}")
+	implementation libs.confluent.kafka.protobuf.serializer
 
-	implementation("org.springframework.boot:spring-boot-starter-webflux")
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
-	implementation("org.apache.kafka:kafka-streams")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
-	implementation("org.springframework.kafka:spring-kafka")
+	implementation libs.spring.boot.starter.webflux
+	implementation libs.jackson.module.kotlin
+	implementation libs.reactor.kotlin.extensions
+	implementation libs.kafka.streams
+	implementation libs.kotlin.reflect
+	implementation libs.kotlin.stdlib.jdk8
+	implementation libs.kotlinx.coroutines.reactor
+	implementation libs.spring.kafka
 
-	testImplementation("org.springframework.boot:spring-boot-starter-test") {
+	testImplementation(libs.spring.boot.starter.test) {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
-	testImplementation("io.projectreactor:reactor-test")
-	testImplementation("org.springframework.kafka:spring-kafka-test")
+	testImplementation libs.reactor.test
+	testImplementation libs.spring.kafka.test
 
-	testImplementation("org.springframework.boot:spring-boot-testcontainers")
+	testImplementation libs.spring.boot.testcontainers
 
-	testImplementation("org.testcontainers:testcontainers:1.20.6")
-	testImplementation("org.testcontainers:junit-jupiter:1.20.6")
-	testImplementation ("org.testcontainers:redpanda:1.20.6")
+	testImplementation libs.bundles.testcontainers
 }
 
 
@@ -71,7 +69,7 @@ compileKotlin {
 protobuf {
 	protoc {
 		// Download from repositories
-		artifact = "com.google.protobuf:protoc:${rootProject.ext.versions.protoc}"
+		artifact = "com.google.protobuf:protoc:${libs.versions.protoc.get()}"
 	}
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,6 @@
 gradle-release = "3.0.2"
 spotbugs = "6.0.28"
 spotless = "6.23.3"
-kotlin = "1.9.25"
-spring-dependency-management = "1.1.7"
-spring-boot = "3.1.12"
 avro-gradle-plugin = "1.9.1"
 protobuf-gradle-plugin = "0.9.5"
 jsonschema2pojo = "1.2.2"
@@ -37,10 +34,6 @@ instancio-junit = "5.5.0"
 # Logging
 logback = "1.4.14"
 
-# Spring (for examples)
-reactor-kotlin-extensions = "1.2.3"
-kotlinx-coroutines-reactor = "1.8.1"
-
 [libraries]
 # Build plugins (for buildscript dependencies)
 protobuf-gradle-plugin = { module = "com.google.protobuf:protobuf-gradle-plugin", version.ref = "protobuf-gradle-plugin" }
@@ -64,7 +57,6 @@ confluent-kafka-schema-serializer = { module = "io.confluent:kafka-schema-serial
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
-jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" }
 commons-beanutils = { module = "commons-beanutils:commons-beanutils", version.ref = "commons-beanutils" }
 
 # Logging
@@ -83,26 +75,10 @@ testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", ve
 testcontainers-redpanda = { module = "org.testcontainers:redpanda", version.ref = "testcontainers" }
 instancio-junit = { module = "org.instancio:instancio-junit", version.ref = "instancio-junit" }
 
-# Spring and Kotlin (for examples)
-spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
-spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
-spring-boot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers" }
-spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
-spring-kafka-test = { module = "org.springframework.kafka:spring-kafka-test" }
-reactor-kotlin-extensions = { module = "io.projectreactor.kotlin:reactor-kotlin-extensions", version.ref = "reactor-kotlin-extensions" }
-reactor-test = { module = "io.projectreactor:reactor-test" }
-kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinx-coroutines-reactor" }
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
-kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
-
 [plugins]
 release = { id = "net.researchgate.release", version.ref = "gradle-release" }
 spotbugs = { id = "com.github.spotbugs", version.ref = "spotbugs" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
-spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-dependency-management" }
-spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
 avro = { id = "com.github.davidmc24.gradle.plugin.avro", version.ref = "avro-gradle-plugin" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobuf-gradle-plugin" }
 jsonschema2pojo = { id = "org.jsonschema2pojo", version.ref = "jsonschema2pojo" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,141 @@
+[versions]
+# Build tools and plugins
+gradle-release = "3.0.2"
+spotbugs = "6.0.28"
+spotless = "6.23.3"
+kotlin = "1.9.25"
+spring-dependency-management = "1.1.7"
+spring-boot = "3.1.12"
+avro-gradle-plugin = "1.9.1"
+protobuf-gradle-plugin = "0.9.5"
+jsonschema2pojo = "1.2.2"
+
+# Core dependencies
+protobuf-java = "3.25.1"
+protoc = "3.25.1"
+avro = "1.11.4"
+kryo = "5.6.2"
+
+# Kafka and Confluent
+kafka-streams = "3.2.3"
+kafka-clients = "3.2.3"
+confluent = "7.5.8"
+
+# JSON processing
+jackson = "2.18.4"
+commons-beanutils = "1.11.0"
+
+# Testing
+junit-jupiter = "5.10.5"
+assertj = "3.24.2"
+commons-lang3 = "3.14.0"
+awaitility = "4.2.2"
+mockito = "5.8.0"
+testcontainers = "1.20.6"
+instancio-junit = "5.5.0"
+
+# Logging
+logback = "1.4.14"
+
+# Spring (for examples)
+reactor-kotlin-extensions = "1.2.3"
+kotlinx-coroutines-reactor = "1.8.1"
+
+[libraries]
+# Build plugins (for buildscript dependencies)
+protobuf-gradle-plugin = { module = "com.google.protobuf:protobuf-gradle-plugin", version.ref = "protobuf-gradle-plugin" }
+
+# Core libraries
+protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf-java" }
+avro = { module = "org.apache.avro:avro", version.ref = "avro" }
+kryo = { module = "com.esotericsoftware:kryo", version.ref = "kryo" }
+
+# Kafka and Confluent
+kafka-streams = { module = "org.apache.kafka:kafka-streams", version.ref = "kafka-streams" }
+kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka-clients" }
+confluent-kafka-avro-serializer = { module = "io.confluent:kafka-avro-serializer", version.ref = "confluent" }
+confluent-kafka-protobuf-serializer = { module = "io.confluent:kafka-protobuf-serializer", version.ref = "confluent" }
+confluent-kafka-streams-protobuf-serde = { module = "io.confluent:kafka-streams-protobuf-serde", version.ref = "confluent" }
+confluent-kafka-schema-registry-client = { module = "io.confluent:kafka-schema-registry-client", version.ref = "confluent" }
+confluent-kafka-json-schema-provider = { module = "io.confluent:kafka-json-schema-provider", version.ref = "confluent" }
+confluent-kafka-schema-serializer = { module = "io.confluent:kafka-schema-serializer", version.ref = "confluent" }
+
+# JSON processing
+jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" }
+commons-beanutils = { module = "commons-beanutils:commons-beanutils", version.ref = "commons-beanutils" }
+
+# Logging
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+
+# Testing
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
+awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
+testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
+testcontainers-redpanda = { module = "org.testcontainers:redpanda", version.ref = "testcontainers" }
+instancio-junit = { module = "org.instancio:instancio-junit", version.ref = "instancio-junit" }
+
+# Spring and Kotlin (for examples)
+spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+spring-boot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers" }
+spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
+spring-kafka-test = { module = "org.springframework.kafka:spring-kafka-test" }
+reactor-kotlin-extensions = { module = "io.projectreactor.kotlin:reactor-kotlin-extensions", version.ref = "reactor-kotlin-extensions" }
+reactor-test = { module = "io.projectreactor:reactor-test" }
+kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinx-coroutines-reactor" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
+
+[plugins]
+release = { id = "net.researchgate.release", version.ref = "gradle-release" }
+spotbugs = { id = "com.github.spotbugs", version.ref = "spotbugs" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
+spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-dependency-management" }
+spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
+avro = { id = "com.github.davidmc24.gradle.plugin.avro", version.ref = "avro-gradle-plugin" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobuf-gradle-plugin" }
+jsonschema2pojo = { id = "org.jsonschema2pojo", version.ref = "jsonschema2pojo" }
+
+[bundles]
+# Common testing dependencies
+testing = [
+    "junit-jupiter",
+    "junit-jupiter-params",
+    "assertj-core",
+    "commons-lang3",
+    "awaitility",
+    "mockito-core",
+    "mockito-junit-jupiter"
+]
+
+# Testcontainers bundle
+testcontainers = [
+    "testcontainers",
+    "testcontainers-junit-jupiter",
+    "testcontainers-redpanda"
+]
+
+# Jackson bundle
+jackson = [
+    "jackson-core",
+    "jackson-databind",
+    "jackson-annotations"
+]
+
+# Confluent bundle
+confluent = [
+    "confluent-kafka-schema-registry-client",
+    "confluent-kafka-json-schema-provider",
+    "confluent-kafka-schema-serializer"
+]

--- a/schema-providers-avro/build.gradle
+++ b/schema-providers-avro/build.gradle
@@ -1,7 +1,7 @@
 
 plugins {
     id 'java-test-fixtures'
-    id "com.github.davidmc24.gradle.plugin.avro" version "1.9.1"
+    alias(libs.plugins.avro)
 
 }
 
@@ -13,6 +13,6 @@ spotbugs {
 dependencies {
     implementation project(':crypto-spi')
     implementation project(':schema-spi')
-    implementation 'org.apache.avro:avro:1.11.4'
-    implementation 'com.esotericsoftware:kryo:5.6.2'
+    implementation libs.avro
+    implementation libs.kryo
 }

--- a/schema-providers-jsonschema/build.gradle
+++ b/schema-providers-jsonschema/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-test-fixtures'
-    id 'org.jsonschema2pojo' version "1.2.2"
+    alias(libs.plugins.jsonschema2pojo)
 
 }
 
@@ -14,17 +14,15 @@ dependencies {
     implementation project(':schema-spi')
     
     // JSON processing dependencies
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.18.4'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.4'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.4'
-    implementation 'commons-beanutils:commons-beanutils:1.11.0'
+    implementation libs.bundles.jackson
+    implementation libs.commons.beanutils
     
     // Testing dependencies
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation 'org.mockito:mockito-core:5.14.2'
-    testImplementation 'org.mockito:mockito-junit-jupiter:5.14.2'
-    testImplementation 'org.instancio:instancio-junit:5.5.0'
+    testImplementation libs.junit.jupiter
+    testImplementation libs.assertj.core
+    testImplementation libs.mockito.core
+    testImplementation libs.mockito.junit.jupiter
+    testImplementation libs.instancio.junit
 }
 
 jsonSchema2Pojo {

--- a/schema-providers-protobuf/build.gradle
+++ b/schema-providers-protobuf/build.gradle
@@ -1,17 +1,17 @@
 buildscript {
     dependencies {
-        classpath "com.google.protobuf:protobuf-gradle-plugin:${rootProject.ext.versions.protobufGradlePlugin}"
+        classpath libs.protobuf.gradle.plugin
     }
 }
 
 plugins {
     id 'java-test-fixtures'
-    id 'com.google.protobuf' version '0.9.5'
+    alias(libs.plugins.protobuf)
 }
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:${rootProject.ext.versions.protoc}"
+        artifact = "com.google.protobuf:protoc:${libs.versions.protoc.get()}"
     }
 }
 
@@ -31,5 +31,5 @@ spotbugs {
 dependencies {
     implementation project(':crypto-spi')
     implementation project(':schema-spi')
-    implementation "com.google.protobuf:protobuf-java:${rootProject.ext.versions.protobufJava}"
+    implementation libs.protobuf.java
 }

--- a/serialization-adapters-kafka/build.gradle
+++ b/serialization-adapters-kafka/build.gradle
@@ -5,18 +5,14 @@ dependencies {
     implementation project(':crypto-providers-kafkakms') //todo service locator / dynamic factory
     implementation project(':schema-providers-jsonschema')
 
-    implementation 'org.apache.kafka:kafka-clients:3.2.3'
-    implementation "io.confluent:kafka-schema-registry-client:${rootProject.ext.versions.confluent}"
-    implementation "io.confluent:kafka-json-schema-provider:${rootProject.ext.versions.confluent}"
-    implementation "io.confluent:kafka-schema-serializer:${rootProject.ext.versions.confluent}"
+    implementation libs.kafka.clients
+    implementation libs.bundles.confluent
 
-    testImplementation "org.testcontainers:testcontainers:1.20.6"
-    testImplementation "org.testcontainers:junit-jupiter:1.20.6"
-    testImplementation "org.testcontainers:redpanda:1.20.6"
+    testImplementation libs.bundles.testcontainers
 
     // To fully test the dynamic class instantiation, we test against all available schema providers
-    testImplementation "com.google.protobuf:protobuf-java:${rootProject.ext.versions.protobufJava}"
-    testImplementation "org.apache.avro:avro:1.11.4"
+    testImplementation libs.protobuf.java
+    testImplementation libs.avro
 
     // TODO: Adopt test features in a way it includes generated source code
     // ref.: for further reading

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,13 @@
 rootProject.name = 'pi2schema'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        exampleLibs {
+            from(files("examples/libs.versions.toml"))
+        }
+    }
+}
+
 include 'crypto-spi'
 include 'crypto-providers-kafkakms'
 include 'crypto-providers-vault'


### PR DESCRIPTION
Created a centralized version catalog `libs.versions.toml` that defines all dependency versions, library aliases, plugin aliases, and useful bundles

Updated all 11 build.gradle files to use the version catalog references instead of hardcoded versions

Eliminated version inconsistencies - for example, JUnit was being used in different versions across modules (5.10.5, 5.11.4), now all use the same version

Simplified dependency declarations using semantic aliases like libs.protobuf.java, libs.bundles.testing, and alias `libs.plugins.spring.boot`

Solves #514 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized dependency and plugin version management across all build scripts using Gradle version catalogs.
  * Updated build scripts to reference version catalog aliases instead of hardcoded version strings.
  * Added new version catalog files for consistent dependency and plugin declarations.
  * Updated `.gitignore` to exclude the `.vscode/` directory.
  * Configured project settings to include additional version catalog for example modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->