### PR TITLE
spec: introduce Schema Definition Providers abstraction

### DIFF
--- a/.instructions-ai/prompts/create-specification.prompt.md
+++ b/.instructions-ai/prompts/create-specification.prompt.md
@@ -19,7 +19,45 @@ The specification file must define the requirements, constraints, and interfaces
 - Include examples and edge cases where applicable.
 - Ensure the document is self-contained and does not rely on external context.
 
-The specification should be saved in the [/spec/](/spec/) directory and named according to the following convention: `spec-[a-z0-9-]+.md`, where the name should be descriptive of the specification's content and starting with the highlevel purpose, which is one of [schema, tool, data, infrastructure, process, architecture, or design].
+## File Naming Convention
+
+**IMPORTANT**: The specification(s) MUST be saved in the [/spec/](/spec/) directory and named according to the following convention: 
+
+`spec-[a-z0-9-]+.md`
+
+Where the name should be descriptive of the specification's content and starting with the highlevel purpose, which is one of [schema, tool, data, infrastructure, process, architecture, or design].
+
+**Examples of correct naming:**
+- `spec-schema-definition-provider.md` (for interface/contract specs)
+- `spec-schema-definition-provider-protobuf.md` (for implementation specs)
+- `spec-tool-migration-utility.md`
+- `spec-data-encryption-format.md`
+
+**Always use the `spec-` prefix - this is mandatory!**
+
+## Specification Architecture Best Practices
+
+When creating specifications, consider separating concerns into multiple focused documents:
+
+### Interface/Contract Specifications
+Create specifications that define generic interfaces, contracts, and abstractions:
+- Focus on defining clear contracts and SPI (Service Provider Interface) patterns
+- Include generic requirements that apply across all implementations
+- Define data contracts and integration patterns
+- Specify architectural principles and separation of concerns
+
+### Implementation Specifications  
+Create separate specifications for concrete implementations:
+- Focus on technology-specific implementation details
+- Reference the interface specifications they implement
+- Include implementation-specific constraints and requirements
+- Provide technology-specific examples and edge cases
+
+### Benefits of Separation
+- **Maintainability**: Changes to implementations don't affect interface contracts
+- **Clarity**: Developers can focus on either interface design or implementation details
+- **Reusability**: Interface specifications can guide multiple implementations
+- **Testability**: Clear separation enables better testing strategies
 
 The specification file must be formatted in well formed Markdown.
 
@@ -125,3 +163,7 @@ tags: [Optional: List of relevant tags or categories, e.g., `infrastructure`, `p
 [Link to relevant external documentation]
 
 ```
+
+---
+
+**REMINDER**: Ensure all created specification files use the mandatory `spec-` prefix (e.g., `spec-schema-provider.md`, NOT `schema-provider.md`)!

--- a/spec/spec-schema-definition-provider-avro.md
+++ b/spec/spec-schema-definition-provider-avro.md
@@ -1,0 +1,288 @@
+---
+title: Local Avro Schema Definition Provider Implementation
+version: 1.0
+date_created: 2025-08-08
+last_updated: 2025-08-13
+owner: pi2schema
+tags: [schema, avro, provider, spi, implementation, local]
+---
+
+# Local Avro Schema Definition Provider Implementation
+
+A specification for implementing a local-only Avro schema definition provider within the pi2schema framework, focusing on extracting Avro Schema information from SpecificRecord and GenericRecord objects using only local reflection capabilities while maintaining compatibility with existing implementations.
+
+## 1. Purpose & Scope
+
+This specification defines the requirements for implementing a local-only Avro schema provider that extracts Schema information from Avro record objects using the built-in `getSchema()` method. The provider maintains backward compatibility with existing Avro implementations by operating without external dependencies like Schema Registry.
+
+**Intended Audience**: Java developers implementing Avro schema providers for the pi2schema framework.
+
+**Assumptions**: 
+- Familiarity with Apache Avro and Schema API
+- Understanding of SpecificRecord interface and Avro code generation
+- Knowledge of the pi2schema SPI architecture
+- Preference for local-only operation without external system dependencies
+
+## 2. Definitions
+
+- **Avro Schema**: Metadata object describing the structure of an Avro record type
+- **SpecificRecord**: Avro interface for generated record classes with compile-time schema access
+- **GenericRecord**: Avro interface for dynamic records with runtime schema access
+- **Field**: Avro schema element describing individual record fields
+- **Union Type**: Avro schema construct representing multiple possible types for a field
+
+## 3. Requirements, Constraints & Guidelines
+
+### Core Requirements
+
+- **REQ-001**: The provider SHALL implement `SchemaProvider<org.apache.avro.Schema>` interface
+- **REQ-002**: The provider SHALL extract Schema from Avro SpecificRecord objects using `getSchema()`
+- **REQ-003**: The provider SHALL support GenericRecord objects with runtime schema access
+- **REQ-004**: The provider SHALL operate in local-only mode without external dependencies
+- **REQ-005**: The provider SHALL ignore schema ID supplier parameters to maintain local behavior
+- **REQ-006**: The provider SHALL handle unknown record types gracefully
+- **REQ-007**: The provider SHALL be thread-safe for concurrent access
+
+### Schema Discovery Requirements
+
+- **REQ-009**: The provider SHALL use `record.getSchema()` for SpecificRecord objects
+- **REQ-010**: The provider SHALL use `record.getSchema()` for GenericRecord objects
+- **REQ-011**: The provider SHALL validate that business objects are Avro record instances
+- **REQ-012**: The provider SHALL maintain compatibility with existing Avro implementations
+- **REQ-013**: The provider SHALL not require external schema registry configuration
+
+### Performance Requirements
+
+- **PER-001**: Schema extraction SHALL be optimized for runtime performance
+- **PER-002**: Provider initialization SHALL be lightweight and fast
+
+### Compatibility Constraints
+
+- **CON-001**: The provider SHALL be compatible with Apache Avro 1.8+ 
+- **CON-002**: The provider SHALL maintain compatibility with existing Avro serializers
+- **CON-003**: The provider SHALL support both SpecificRecord and GenericRecord implementations
+- **CON-004**: The provider SHALL work without Schema Registry dependencies
+
+### Error Handling Guidelines
+
+- **GUD-001**: Throw `SchemaNotFoundException` for non-Avro business objects
+- **GUD-002**: Provide clear error messages for invalid record types
+- **GUD-003**: Handle null business objects gracefully
+- **GUD-004**: Log appropriate debugging information for troubleshooting
+
+## 4. Interfaces & Data Contracts
+
+### Core Interface Implementation
+
+```java
+package pi2schema.schema.providers.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.specific.SpecificRecord;
+import pi2schema.schema.SchemaProvider;
+import pi2schema.schema.SchemaNotFoundException;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Local Avro schema provider that extracts Schema information
+ * from Avro SpecificRecord and GenericRecord objects using only local capabilities.
+ * This provider maintains compatibility with existing Avro implementations
+ * by avoiding Schema Registry dependencies.
+ */
+public class LocalAvroSchemaProvider implements SchemaProvider<Schema> {
+    
+    @Override
+    public Schema schemaFor(Object businessObject, Supplier<Optional<Integer>> schemaIdSupplier) {
+        // Local-only implementation - schema ID supplier is ignored
+        return extractSchemaFromRecord(businessObject);
+    }
+    
+    private Schema extractSchemaFromRecord(Object businessObject) {
+        if (businessObject == null) {
+            throw new SchemaNotFoundException("Business object cannot be null");
+        }
+        
+        if (businessObject instanceof SpecificRecord) {
+            return ((SpecificRecord) businessObject).getSchema();
+        } else if (businessObject instanceof GenericRecord) {
+            return ((GenericRecord) businessObject).getSchema();
+        } else {
+            throw new SchemaNotFoundException(
+                "Object is not an Avro record (SpecificRecord or GenericRecord): " + 
+                businessObject.getClass().getName()
+            );
+        }
+    }
+}
+```
+
+### Schema Utility Methods
+
+```java
+/**
+ * Utility methods for Avro schema operations.
+ */
+public class AvroSchemaUtils {
+    
+    /**
+     * Validates that the schema is suitable for PII analysis.
+     */
+    public static void validateSchemaForPiiAnalysis(Schema schema) {
+        if (schema.getType() != Schema.Type.RECORD) {
+            throw new IllegalArgumentException("Schema must be a RECORD type for PII analysis");
+        }
+    }
+    
+    /**
+     * Extracts field schemas for union type analysis.
+     */
+    public static List<Schema> extractUnionSchemas(Schema.Field field) {
+        if (field.schema().getType() == Schema.Type.UNION) {
+            return field.schema().getTypes();
+        }
+        return Collections.singletonList(field.schema());
+    }
+}
+```
+
+### Data Contracts
+
+#### Input Requirements
+- Business object MUST be an instance of `SpecificRecord` or `GenericRecord`
+- Business object MUST NOT be null
+- Schema ID supplier parameter is ignored (local-only operation)
+
+#### Output Requirements
+- Returns `org.apache.avro.Schema` instance
+- Schema MUST contain complete field metadata
+- Schema MUST be suitable for PII analysis by PersonalMetadataProvider
+- Schema MUST include union type information where applicable
+
+## 5. Acceptance Criteria
+
+- **AC-001**: Given an Avro SpecificRecord object, When schemaFor() is called, Then it returns the correct Schema from getSchema()
+- **AC-002**: Given an Avro GenericRecord object, When schemaFor() is called, Then it returns the correct Schema from getSchema()
+- **AC-003**: Given a schema ID supplier parameter, When schemaFor() is called, Then it ignores the schema ID and uses local extraction
+- **AC-004**: Given a non-Avro object, When schemaFor() is called, Then it throws SchemaNotFoundException with clear error message
+- **AC-005**: Given a null business object, When schemaFor() is called, Then it throws SchemaNotFoundException gracefully
+- **AC-006**: Given an AvroPersonalMetadataProvider, When it receives a Schema from this provider, Then it successfully analyzes PII fields
+
+## 6. Test Automation Strategy
+
+### Unit Testing
+- Test Schema extraction from various SpecificRecord implementations
+- Test Schema extraction from GenericRecord instances
+- Test error handling for invalid business objects
+- Test union type handling
+- Test null object handling
+
+### Integration Testing
+- Test with real Avro generated classes
+- Test compatibility with PersonalMetadataProvider implementations
+- Test thread safety under concurrent access
+- Test with complex Avro schemas including unions and nested records
+
+### Performance Testing
+- Benchmark Schema extraction performance
+- Monitor memory usage for Schema objects
+- Test performance with large Avro schemas
+
+## 7. Rationale & Context
+
+### Design Decisions
+
+**Local-Only Operation**: Maintaining compatibility with existing Avro implementations by avoiding external dependencies like Schema Registry, keeping the provider simple and focused.
+
+**Support for Both SpecificRecord and GenericRecord**: This provides maximum flexibility for different Avro usage patterns - compiled classes and dynamic records.
+
+**Ignoring Schema ID Supplier**: To maintain backward compatibility, the provider accepts the schema ID supplier parameter but ignores it, always using local schema extraction.
+
+**Union Type Awareness**: Avro's union types are common for optional fields and versioning, so the provider must handle them properly for PII analysis.
+
+### Migration from Current Implementation
+
+The current AvroPersonalMetadataProvider directly calls `record.getSchema()`. This will be refactored to:
+1. Use the new LocalAvroSchemaProvider for schema discovery
+2. Accept Schema objects in the `forSchema()` method
+3. Maintain backward compatibility through deprecated `forType()` method
+
+## 8. Dependencies & External Integrations
+
+### Infrastructure Dependencies
+- **INF-001**: pi2schema schema-spi - Core SchemaProvider interface
+- **INF-002**: Apache Avro - Schema and record interfaces
+
+### External Systems
+- **None**: This provider operates locally without external system dependencies
+
+### Technology Platform Dependencies
+- **PLT-001**: Java 17+ - Platform requirement
+- **PLT-002**: Apache Avro 1.8+ - Core dependency for Avro support
+
+## 9. Examples & Edge Cases
+
+### Basic Usage Example
+```java
+// Create provider
+LocalAvroSchemaProvider provider = new LocalAvroSchemaProvider();
+
+// Extract schema from SpecificRecord (schema ID supplier is ignored)
+User user = User.newBuilder()
+    .setUserId("user-123")
+    .setEmail("user@example.com")
+    .build();
+
+Schema schema = provider.schemaFor(user, null); // Schema ID supplier ignored
+
+// Use with PersonalMetadataProvider
+AvroPersonalMetadataProvider<User> metadataProvider = 
+    new AvroPersonalMetadataProvider<>();
+PersonalMetadata<User> metadata = metadataProvider.forSchema(schema);
+```
+
+### GenericRecord Example
+```java
+// GenericRecord scenario
+GenericRecord genericUser = new GenericData.Record(userSchema);
+genericUser.put("userId", "user-123");
+genericUser.put("email", "user@example.com");
+
+Schema schema = provider.schemaFor(genericUser, null); // Schema ID supplier ignored
+```
+
+### Compatibility Example
+```java
+// Demonstrates that schema ID supplier is ignored
+Supplier<Optional<Integer>> schemaIdSupplier = () -> Optional.of(123);
+Schema schema1 = provider.schemaFor(record, schemaIdSupplier);
+Schema schema2 = provider.schemaFor(record, null);
+// Both calls return the same schema from getSchema()
+assert schema1 == schema2;
+```
+
+### Edge Cases
+- **Union Types**: Provider handles nullable fields (union with null)
+- **Nested Records**: Provider returns complete Schema including nested record types
+- **Array and Map Fields**: Provider includes collection type schemas
+- **Schema Evolution**: Provider handles backward compatible schema changes
+- **Logical Types**: Provider preserves logical type information (timestamps, decimals, etc.)
+- **Schema ID Supplied**: Provider ignores schema ID and always uses local extraction
+
+## 10. Validation Criteria
+
+- Provider successfully extracts Schemas from all standard Avro record types
+- Schema ID supplier parameter is properly ignored while maintaining interface compatibility
+- Union type handling preserves all necessary metadata for PII analysis
+- Error handling provides clear guidance for common configuration mistakes
+- Performance metrics show acceptable overhead for Schema extraction
+- Thread safety is maintained under concurrent access
+- Compatibility is maintained with existing Avro PersonalMetadataProvider
+
+## 11. Related Specifications / Further Reading
+
+- [Schema Definition Provider Architecture](spec-schema-definition-provider.md)
+- [Avro Personal Metadata Provider](../schema-providers-avro/README.md)
+- [Apache Avro Documentation](https://avro.apache.org/docs/current/)

--- a/spec/spec-schema-definition-provider-jsonschema.md
+++ b/spec/spec-schema-definition-provider-jsonschema.md
@@ -1,0 +1,308 @@
+---
+title: JSON Schema Definition Provider Implementation
+version: 1.0
+date_created: 2025-08-08
+last_updated: 2025-08-08
+owner: pi2schema
+tags: [schema, json-schema, provider, spi, implementation]
+---
+
+# JSON Schema Definition Provider Implementation
+
+A specification for implementing JSON Schema definition discovery within the pi2schema framework, focusing on extracting JSON Schema information from business objects while maintaining separation from PII metadata analysis.
+
+## 1. Purpose & Scope
+
+This specification defines the requirements for implementing a JSON Schema-specific provider that discovers schema definitions for business objects. Unlike Protobuf and Avro which have built-in schema methods, JSON Schema requires more sophisticated discovery mechanisms including annotation-based detection, Schema Registry integration, and object introspection.
+
+**Intended Audience**: Java developers implementing JSON Schema providers for the pi2schema framework.
+
+**Assumptions**: 
+- Familiarity with JSON Schema specification (Draft 7 or later)
+- Understanding of Jackson JSON processing and object mapping
+- Knowledge of the pi2schema SPI architecture
+- Understanding of Kafka serialization patterns with JSON Schema
+
+## 2. Definitions
+
+- **JSON Schema**: JSON document describing the structure, constraints, and metadata of JSON data
+- **Business Object**: Any Java object that can be serialized to JSON (POJO, Map, etc.)
+- **Schema Registry**: External system storing and versioning JSON schemas
+- **JsonNode**: Jackson representation of parsed JSON Schema documents
+- **Schema Annotation**: Java annotations indicating schema location or metadata
+- **Schema Inference**: Process of deriving schema from object structure
+
+## 3. Requirements, Constraints & Guidelines
+
+### Core Requirements
+
+- **REQ-001**: The provider SHALL implement `SchemaProvider<JsonNode>` interface  
+- **REQ-002**: The provider SHALL support schema discovery from Schema Registry
+- **REQ-003**: The provider SHALL integrate with Kafka Schema Registry when schema ID is provided
+- **REQ-004**: The provider SHALL support basic schema discovery for business objects
+- **REQ-005**: The provider SHALL handle any serializable Java object type
+- **REQ-006**: The provider SHALL be thread-safe for concurrent access
+- **REQ-007**: The provider SHALL provide clear error messages when schema discovery fails
+
+### Schema Discovery Strategies
+
+- **REQ-009**: Consumer scenario SHALL retrieve schema from Schema Registry using provided schema ID
+- **REQ-010**: Producer scenario SHALL lookup schema in Schema Registry  
+- **REQ-011**: The provider SHALL support Confluent Schema Registry JSON Schema format
+- **REQ-012**: The provider SHALL handle schema evolution and compatibility rules
+
+### Schema Registry Integration
+
+- **REQ-013**: The provider SHALL integrate with Kafka Schema Registry when schema ID is provided
+- **REQ-014**: The provider SHALL support basic schema discovery for producer scenarios
+- **REQ-015**: The provider SHALL handle schema registry connectivity issues gracefully
+
+### Performance Requirements
+
+- **PER-001**: Schema discovery SHALL be optimized for runtime performance
+
+### Compatibility Constraints
+
+- **CON-001**: The provider SHALL be compatible with Jackson 2.x
+- **CON-002**: The provider SHALL work with Confluent Schema Registry
+- **CON-003**: The provider SHALL support standard JSON Schema Draft 7+
+- **CON-004**: The provider SHALL maintain compatibility with existing JSON serializers
+
+### Error Handling Guidelines
+
+- **GUD-001**: Throw `SchemaNotFoundException` when no discovery strategy succeeds
+- **GUD-002**: Provide clear error messages indicating which strategies were attempted
+- **GUD-003**: Handle null business objects gracefully
+- **GUD-004**: Log appropriate debugging information for troubleshooting
+- **GUD-005**: Support fallback to schema inference as last resort
+
+## 4. Interfaces & Data Contracts
+
+### Core Interface Implementation
+
+```java
+package pi2schema.schema.providers.jsonschema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import pi2schema.schema.SchemaProvider;
+import pi2schema.schema.SchemaNotFoundException;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * JSON Schema-specific provider that discovers schema definitions
+ * for business objects, primarily through Schema Registry integration.
+ */
+public class JsonSchemaProvider implements SchemaProvider<JsonNode> {
+    
+    private final ObjectMapper objectMapper;
+    
+    public JsonSchemaProvider() {
+        this.objectMapper = new ObjectMapper();
+    }
+    
+    @Override
+    public JsonNode schemaFor(Object businessObject, Supplier<Optional<Integer>> schemaIdSupplier) {
+        // Consumer case: schema ID is provided (from Kafka headers)
+        if (schemaIdSupplier != null) {
+            Optional<Integer> schemaId = schemaIdSupplier.get();
+            if (schemaId.isPresent()) {
+                return getSchemaById(schemaId.get());
+            }
+        }
+        
+        // Producer case: basic schema discovery
+        return discoverSchemaForProducer(businessObject);
+    }
+    
+    private JsonNode getSchemaById(Integer schemaId) {
+        // Implementation for Schema Registry integration
+        throw new UnsupportedOperationException("Schema Registry integration not yet implemented");
+    }
+    
+    private JsonNode discoverSchemaForProducer(Object businessObject) {
+        // Basic implementation - to be extended with discovery strategies in future versions
+        throw new SchemaNotFoundException(
+            "Producer schema discovery not yet implemented for object type: " + 
+            businessObject.getClass().getName()
+        );
+    }
+}
+```
+
+### Acceptance Criteria
+
+- **AC-01**: JsonSchemaProvider implements SchemaProvider&lt;JsonNode&gt; interface
+- **AC-02**: Schema Registry integration returns schemas by ID for consumer use cases
+- **AC-03**: Provider returns JsonNode schemas compatible with PersonalMetadataProvider.forSchema()
+- **AC-04**: Jackson ObjectMapper is used for JSON processing
+- **AC-05**: SchemaNotFoundException is thrown when schemas cannot be resolved
+- **AC-06**: Provider implements fallback logic when schema ID is not available
+
+## Future Enhancements
+
+The following features may be considered for future versions but are not part of the initial implementation:
+
+### Advanced Discovery Strategies
+- **Annotation-based Strategy**: Discovery through schema annotations on classes
+- **Convention-based Strategy**: Discovery using naming conventions and file system paths  
+- **Inference Strategy**: Dynamic schema generation from object structure
+- **Multiple Strategy Support**: Configurable discovery strategy chains with fallback mechanisms
+
+These enhancements would extend the basic Schema Registry integration with more sophisticated discovery mechanisms for producer scenarios where schema IDs are not available.
+
+## 5. Implementation Considerations
+
+### Dependencies
+
+- Jackson 2.x for JSON processing
+- Confluent Schema Registry client
+- SLF4J for logging
+
+### Configuration
+
+```java
+// Basic configuration example
+JsonSchemaProvider provider = new JsonSchemaProvider();
+PersonalMetadataProvider<JsonNode> metadataProvider = 
+    PersonalMetadataProvider.forSchema(provider);
+```
+
+### Integration with Kafka
+
+```java
+// Example Kafka integration
+SchemaRegistryClient registryClient = new CachedSchemaRegistryClient(registryUrl, 100);
+JsonSchemaProvider schemaProvider = new JsonSchemaProvider(registryClient);
+
+// In consumer
+Integer schemaId = getSchemaIdFromKafkaHeaders(consumerRecord);
+JsonNode schema = schemaProvider.schemaFor(businessObject, () -> Optional.of(schemaId));
+```
+
+## 6. Testing Considerations
+
+### Unit Testing Requirements
+
+- Test schema resolution with valid Schema Registry IDs
+- Test error handling for invalid schema IDs  
+- Test fallback behavior when schema ID is not provided
+- Test JSON parsing and validation
+- Test integration with PersonalMetadataProvider
+
+### Integration Testing
+
+- Test with actual Schema Registry instance
+- Test Kafka consumer/producer integration
+- Test schema evolution scenarios
+- Verify compatibility with different JSON Schema versions
+
+### Performance Testing
+
+- Benchmark schema lookup performance
+- Test memory usage patterns
+- Test concurrent access scenarios
+
+## 7. Dependencies & External Integrations
+
+### Infrastructure Dependencies
+- **INF-001**: pi2schema schema-spi - Core SchemaProvider interface
+- **INF-002**: Jackson Core - JSON processing and JsonNode representation
+- **INF-003**: Jackson Databind - Object mapping and introspection
+
+### External Systems
+- **EXT-001**: Confluent Schema Registry - Schema storage and versioning (optional)
+
+### Technology Platform Dependencies
+- **PLT-001**: Java 17+ - Platform requirement
+- **PLT-002**: Jackson 2.x - JSON processing library
+- **PLT-003**: Confluent Schema Registry Client - For Kafka integration (optional)
+
+## 8. Examples & Edge Cases
+
+### Basic Usage Example
+```java
+// Basic provider setup
+JsonSchemaProvider schemaProvider = new JsonSchemaProvider();
+PersonalMetadataProvider<JsonNode> metadataProvider = 
+    PersonalMetadataProvider.forSchema(schemaProvider);
+
+// Consumer scenario with schema ID
+Integer schemaId = getSchemaIdFromKafkaHeaders(consumerRecord);
+JsonNode schema = schemaProvider.schemaFor(businessObject, () -> Optional.of(schemaId));
+
+// Analyze PII metadata
+Set<String> piiFields = metadataProvider.personalDataFields(businessObject);
+```
+
+### Error Handling Examples
+
+```java
+try {
+    JsonNode schema = schemaProvider.schemaFor(businessObject, () -> Optional.empty());
+} catch (SchemaNotFoundException e) {
+    log.warn("Schema not found for object type: {}", businessObject.getClass().getName());
+    // Handle missing schema scenario
+}
+```
+
+### Edge Cases
+
+- **Null Objects**: Provider handles null business objects gracefully
+- **Missing Schema ID**: Falls back to producer discovery when schema ID is not available
+- **Schema Registry Unavailable**: Throws appropriate exceptions with clear error messages
+- **Invalid Schema Format**: Validates schema content before returning JsonNode
+- **Concurrent Access**: Thread-safe operations for high-throughput scenarios
+
+## 9. Migration & Compatibility
+
+### From Existing Implementation
+
+The current JsonSchemaPersonalMetadataProvider will be updated to:
+1. Accept schemas from JsonSchemaProvider
+2. Remove internal schema discovery logic
+3. Maintain backward compatibility through deprecated methods
+4. Provide migration path for existing users
+
+### Backward Compatibility
+
+- Existing PersonalMetadataProvider.forSchema() methods remain functional
+- Deprecated methods provide bridge to new architecture
+- Clear migration documentation and examples provided
+
+### Kafka Consumer Example
+```java
+// Consumer scenario - schema ID from Kafka headers
+Supplier<Optional<Integer>> schemaIdSupplier = () -> Optional.of(schemaId);
+JsonNode schema = provider.schemaFor(deserializedObject, schemaIdSupplier);
+```
+
+### Edge Cases
+- **Circular References**: Provider should handle objects with circular references gracefully
+- **Generic Collections**: Provider should infer appropriate array/object schemas for collections
+- **Null Values**: Provider should handle objects with null fields appropriately
+- **Complex Inheritance**: Provider should handle polymorphic object hierarchies
+- **Missing Resources**: Provider should provide clear error messages for missing schema files
+- **Invalid JSON Schema**: Provider should validate loaded schemas and report format errors
+
+## 10. Validation Criteria
+
+- Provider successfully discovers schemas using all configured strategies
+- Schema Registry integration works with both producer and consumer scenarios
+- Annotation-based discovery loads schemas from classpath resources correctly
+- Convention-based discovery follows expected naming patterns
+- Schema inference generates valid JSON Schema documents
+- Error handling provides clear guidance for schema discovery failures
+- Performance metrics show acceptable overhead for schema discovery
+- Thread safety is maintained under concurrent access
+- Compatibility is maintained with existing JSON Schema PersonalMetadataProvider
+
+## 11. Related Specifications / Further Reading
+
+- [Schema Definition Provider Architecture](spec-schema-definition-provider.md)
+- [JSON Schema Personal Metadata Provider](spec-schema-jsonschema-provider.md)
+- [Kafka Serialization Adapters](../serialization-adapters-kafka/README.md)
+- [JSON Schema Specification](https://json-schema.org/)
+- [Confluent Schema Registry JSON Schema Support](https://docs.confluent.io/platform/current/schema-registry/serdes-develop/serdes-json.html)

--- a/spec/spec-schema-definition-provider-protobuf.md
+++ b/spec/spec-schema-definition-provider-protobuf.md
@@ -1,0 +1,228 @@
+---
+title: Local Protobuf Schema Definition Provider Implementation
+version: 1.0
+date_created: 2025-08-08
+last_updated: 2025-08-13
+owner: pi2schema
+tags: [schema, protobuf, provider, spi, implementation, local]
+---
+
+# Local Protobuf Schema Definition Provider Implementation
+
+A specification for implementing a local-only Protobuf schema definition provider within the pi2schema framework, focusing on extracting Protobuf Descriptor information from Message objects using only local reflection capabilities while maintaining compatibility with existing implementations.
+
+## 1. Purpose & Scope
+
+This specification defines the requirements for implementing a local-only Protobuf schema provider that extracts Descriptor information from Protobuf Message objects using the built-in `getDescriptorForType()` method. The provider maintains backward compatibility with existing protobuf implementations by operating without external dependencies like Schema Registry.
+
+**Intended Audience**: Java developers implementing Protobuf schema providers for the pi2schema framework.
+
+**Assumptions**: 
+- Familiarity with Google Protocol Buffers and Descriptor API
+- Understanding of Protobuf Message interface and reflection capabilities
+- Knowledge of the pi2schema SPI architecture
+- Preference for local-only operation without external system dependencies
+
+## 2. Definitions
+
+- **Protobuf Descriptor**: Metadata object describing the structure of a Protobuf message type
+- **Message**: Google Protobuf base interface for all generated message classes
+- **Field Descriptor**: Metadata describing individual fields within a Protobuf message
+- **OneOf Descriptor**: Metadata describing oneOf field groups in Protobuf messages
+
+## 3. Requirements, Constraints & Guidelines
+
+### Core Requirements
+
+- **REQ-001**: The provider SHALL implement `SchemaProvider<Descriptor>` interface
+- **REQ-002**: The provider SHALL extract Descriptor from Protobuf Message objects using `getDescriptorForType()`
+- **REQ-003**: The provider SHALL operate in local-only mode without external dependencies
+- **REQ-004**: The provider SHALL ignore schema ID supplier parameters to maintain local behavior
+- **REQ-005**: The provider SHALL handle unknown message types gracefully
+- **REQ-006**: The provider SHALL be thread-safe for concurrent access
+
+### Schema Discovery Requirements
+
+- **REQ-008**: The provider SHALL use `message.getDescriptorForType()` for all schema discovery
+- **REQ-009**: The provider SHALL validate that business objects are Protobuf Message instances
+- **REQ-010**: The provider SHALL maintain compatibility with existing protobuf implementations
+- **REQ-011**: The provider SHALL not require external schema registry configuration
+
+### Performance Requirements
+
+- **PER-001**: Descriptor extraction SHALL be optimized for runtime performance
+- **PER-002**: Provider initialization SHALL be lightweight and fast
+
+### Compatibility Constraints
+
+- **CON-001**: The provider SHALL be compatible with Google Protobuf 3.x and later
+- **CON-002**: The provider SHALL maintain compatibility with existing Protobuf serializers
+- **CON-003**: The provider SHALL support generated and dynamic Protobuf messages
+- **CON-004**: The provider SHALL work without Schema Registry dependencies
+
+### Error Handling Guidelines
+
+- **GUD-001**: Throw `SchemaNotFoundException` for non-Protobuf business objects
+- **GUD-002**: Provide clear error messages for invalid message types
+- **GUD-003**: Handle null business objects gracefully
+- **GUD-004**: Log appropriate debugging information for troubleshooting
+
+## 4. Interfaces & Data Contracts
+
+### Core Interface Implementation
+
+```java
+package pi2schema.schema.providers.protobuf;
+
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Message;
+import pi2schema.schema.SchemaProvider;
+import pi2schema.schema.SchemaNotFoundException;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Local Protobuf schema provider that extracts Descriptor information
+ * from Protobuf Message objects using only local reflection capabilities.
+ * This provider maintains compatibility with existing protobuf implementations
+ * by avoiding Schema Registry dependencies.
+ */
+public class LocalProtobufSchemaProvider implements SchemaProvider<Descriptor> {
+    
+    @Override
+    public Descriptor schemaFor(Object businessObject, Supplier<Optional<Integer>> schemaIdSupplier) {
+        // Local-only implementation - schema ID supplier is ignored
+        return extractDescriptorFromMessage(businessObject);
+    }
+    
+    private Descriptor extractDescriptorFromMessage(Object businessObject) {
+        if (businessObject == null) {
+            throw new SchemaNotFoundException("Business object cannot be null");
+        }
+        
+        if (!(businessObject instanceof Message)) {
+            throw new SchemaNotFoundException(
+                "Object is not a Protobuf Message: " + businessObject.getClass().getName()
+            );
+        }
+        
+        Message message = (Message) businessObject;
+        return message.getDescriptorForType();
+    }
+}
+```
+
+### Data Contracts
+
+#### Input Requirements
+- Business object MUST be an instance of `com.google.protobuf.Message`
+- Business object MUST NOT be null
+- Schema ID supplier parameter is ignored (local-only operation)
+
+#### Output Requirements
+- Returns `com.google.protobuf.Descriptors.Descriptor` instance
+- Descriptor MUST contain complete field metadata
+- Descriptor MUST be suitable for PII analysis by PersonalMetadataProvider
+
+## 5. Acceptance Criteria
+
+- **AC-001**: Given a Protobuf Message object, When schemaFor() is called, Then it returns the correct Descriptor from getDescriptorForType()
+- **AC-002**: Given a schema ID supplier parameter, When schemaFor() is called, Then it ignores the schema ID and uses local extraction
+- **AC-003**: Given a non-Protobuf object, When schemaFor() is called, Then it throws SchemaNotFoundException with clear error message
+- **AC-004**: Given a null business object, When schemaFor() is called, Then it throws SchemaNotFoundException gracefully
+- **AC-005**: Given a ProtobufPersonalMetadataProvider, When it receives a Descriptor from this provider, Then it successfully analyzes PII fields
+
+## 6. Test Automation Strategy
+
+### Unit Testing
+- Test Descriptor extraction from various Protobuf Message types
+- Test error handling for invalid business objects
+- Test null object handling
+
+### Integration Testing
+- Test with real Protobuf generated classes
+- Test compatibility with PersonalMetadataProvider implementations
+- Test thread safety under concurrent access
+
+### Performance Testing
+- Benchmark Descriptor extraction performance
+- Monitor memory usage for Descriptor objects
+
+## 7. Rationale & Context
+
+### Design Decisions
+
+**Local-Only Operation**: Maintaining compatibility with existing protobuf implementations by avoiding external dependencies like Schema Registry, keeping the provider simple and focused.
+
+**Direct Message Interface Usage**: Using the standard Protobuf Message interface ensures compatibility with all generated Protobuf classes and provides access to the standard `getDescriptorForType()` method.
+
+**Ignoring Schema ID Supplier**: To maintain backward compatibility, the provider accepts the schema ID supplier parameter but ignores it, always using local descriptor extraction.
+
+**Error Handling**: Providing specific exceptions and error messages helps developers quickly identify and resolve configuration issues.
+
+## 8. Dependencies & External Integrations
+
+### Infrastructure Dependencies
+- **INF-001**: pi2schema schema-spi - Core SchemaProvider interface
+- **INF-002**: Google Protocol Buffers - Message interface and Descriptor API
+
+### External Systems
+- **None**: This provider operates locally without external system dependencies
+
+### Technology Platform Dependencies
+- **PLT-001**: Java 17+ - Platform requirement
+- **PLT-002**: Google Protobuf 3.x+ - Core dependency for Protobuf support
+
+## 9. Examples & Edge Cases
+
+### Basic Usage Example
+```java
+// Create provider
+LocalProtobufSchemaProvider provider = new LocalProtobufSchemaProvider();
+
+// Extract descriptor from business object (schema ID supplier is ignored)
+MyProtobufMessage message = MyProtobufMessage.newBuilder()
+    .setUserId("user-123")
+    .setEmail("user@example.com")
+    .build();
+
+Descriptor schema = provider.schemaFor(message, null); // Schema ID supplier ignored
+
+// Use with PersonalMetadataProvider
+ProtobufPersonalMetadataProvider<MyProtobufMessage> metadataProvider = 
+    new ProtobufPersonalMetadataProvider<>();
+PersonalMetadata<MyProtobufMessage> metadata = metadataProvider.forSchema(schema);
+```
+
+### Compatibility Example
+```java
+// Demonstrates that schema ID supplier is ignored
+Supplier<Optional<Integer>> schemaIdSupplier = () -> Optional.of(123);
+Descriptor schema1 = provider.schemaFor(message, schemaIdSupplier);
+Descriptor schema2 = provider.schemaFor(message, null);
+// Both calls return the same descriptor from getDescriptorForType()
+assert schema1 == schema2;
+```
+
+### Edge Cases
+- **Dynamic Messages**: Provider handles dynamically created Protobuf messages
+- **Empty Messages**: Provider handles messages with no fields gracefully
+- **Deprecated Fields**: Provider includes deprecated fields in the Descriptor
+- **Nested Messages**: Provider returns complete Descriptor including nested types
+- **Schema ID Supplied**: Provider ignores schema ID and always uses local extraction
+
+## 10. Validation Criteria
+
+- Provider successfully extracts Descriptors from all standard Protobuf Message types
+- Schema ID supplier parameter is properly ignored while maintaining interface compatibility
+- Error handling provides clear guidance for common configuration mistakes
+- Performance metrics show acceptable overhead for Descriptor extraction
+- Thread safety is maintained under concurrent access
+- Compatibility is maintained with existing Protobuf PersonalMetadataProvider
+
+## 11. Related Specifications / Further Reading
+
+- [Schema Definition Provider Architecture](spec-schema-definition-provider.md)
+- [Protobuf Personal Metadata Provider](../schema-providers-protobuf/README.md)
+- [Google Protocol Buffers Documentation](https://developers.google.com/protocol-buffers)

--- a/spec/spec-schema-definition-provider.md
+++ b/spec/spec-schema-definition-provider.md
@@ -1,0 +1,274 @@
+---
+title: Schema Definition Provider Architecture for Pi2Schema Framework
+version: 1.0
+date_created: 2025-08-08
+last_updated: 2025-08-08
+owner: pi2schema
+tags: [schema, spi, architecture, provider, abstraction]
+---
+
+# Schema Definition Provider Architecture for Pi2Schema Framework
+
+A specification defining the architectural separation between schema definition retrieval and personal metadata analysis within the pi2schema framework, establishing clear SPI interfaces for schema providers and their interaction with metadata providers.
+
+## 1. Purpose & Scope
+
+This specification defines the requirements for implementing a clear separation of concerns between schema definition retrieval and PII metadata analysis. The goal is to establish a consistent architecture where `SchemaProvider` interfaces handle schema definition discovery, while `PersonalMetadataProvider` interfaces receive schema definitions as parameters instead of extracting them directly from business objects.
+
+**Intended Audience**: Java developers implementing schema providers and adapters for the pi2schema framework.
+
+**Assumptions**: 
+- Familiarity with Service Provider Interface (SPI) patterns
+- Understanding of schema definition formats (Protobuf, Avro, JSON Schema)
+- Knowledge of dependency injection and interface-based design
+- Understanding of Kafka serialization and adapter patterns
+
+## 2. Definitions
+
+- **Schema Definition**: The structural metadata describing data format (e.g., Protobuf Descriptor, Avro Schema, JSON Schema)
+- **Schema Provider**: Component responsible for discovering/retrieving schema definitions from business objects
+- **Personal Metadata Provider**: Component responsible for analyzing schema definitions to identify PII fields
+- **Business Object**: The actual data object being processed (e.g., Protobuf Message, Avro SpecificRecord, POJO)
+- **SPI (Service Provider Interface)**: Generic interface defining contracts for implementations
+- **Provider**: Concrete implementation of SPI interfaces for specific technologies
+- **Adapter**: Integration component bridging providers with external systems
+
+## 3. Requirements, Constraints & Guidelines
+
+### Core Architecture Requirements
+
+- **REQ-001**: `SchemaProvider<S>` interface SHALL be responsible for schema definition discovery only
+- **REQ-002**: `PersonalMetadataProvider<T>` interface SHALL accept schema definitions as parameters
+- **REQ-003**: Schema providers SHALL be technology-specific (Protobuf, Avro, JSON Schema)
+- **REQ-004**: Personal metadata providers SHALL be decoupled from schema discovery logic
+- **REQ-005**: Adapters/Interceptors SHALL orchestrate the interaction between schema and metadata providers
+- **REQ-006**: All schema providers SHALL implement the generic `SchemaProvider<S>` SPI interface
+- **REQ-007**: Schema providers SHALL support both producer and consumer scenarios
+
+### Method Signature Requirements
+
+- **REQ-008**: `SchemaProvider.schemaFor(Object, Supplier<Optional<Integer>>)` SHALL return schema definition
+- **REQ-009**: `PersonalMetadataProvider.forSchema(S schema)` SHALL accept schema definition parameter
+- **REQ-010**: Schema providers SHALL handle schema registry integration when applicable
+
+### Separation of Concerns Constraints
+
+- **CON-001**: Schema providers SHALL NOT perform PII analysis
+- **CON-002**: Personal metadata providers SHALL NOT perform schema discovery
+- **CON-003**: Business object introspection SHALL be limited to schema providers only
+- **CON-004**: The implementation SHALL be compatible with Java 17+
+
+### Performance Requirements
+
+- **PER-001**: Schema discovery SHALL be optimized for runtime performance
+- **PER-002**: Schema definitions SHALL be reusable across multiple metadata operations
+- **PER-003**: Provider initialization SHALL be optimized for runtime performance
+
+### Implementation Guidelines
+
+- **GUD-001**: Use composition over inheritance for provider implementations
+- **GUD-002**: Implement fail-fast validation for invalid schema definitions
+- **GUD-003**: Provide clear error messages for unsupported schema formats
+- **GUD-004**: Follow existing package structure patterns: `pi2schema.schema.providers.<technology>`
+- **GUD-005**: Use dependency injection for provider configuration in adapters
+
+## 4. Interfaces & Data Contracts
+
+### Core SPI Interfaces
+
+#### SchemaProvider<S> Interface
+```java
+public interface SchemaProvider<S> {
+    /**
+     * Discovers the schema for a given business object using optional schema identifier.
+     * @param businessObject The object to find schema for
+     * @param schemaIdSupplier Optional supplier providing schema ID (e.g., from Kafka headers)
+     * @return The schema definition instance
+     * @throws SchemaNotFoundException if no schema can be found
+     */
+    S schemaFor(Object businessObject, Supplier<Optional<Integer>> schemaIdSupplier);
+    
+    /**
+     * Discovers the schema for a given business object without additional context.
+     * @param businessObject The object to find schema for
+     * @return The schema definition instance
+     */
+    default S schemaFor(Object businessObject) {
+        return schemaFor(businessObject, null);
+    }
+}
+```
+
+#### Enhanced PersonalMetadataProvider<T> Interface
+```java
+public interface PersonalMetadataProvider<T> {
+    /**
+     * Creates PersonalMetadata for a given schema definition.
+     * This is the method for schema-based providers.
+     * @param schema The schema definition to analyze
+     * @return PersonalMetadata containing PII field definitions
+     */
+    PersonalMetadata<T> forSchema(S schema);
+}
+```
+
+### Technology-Specific Providers
+
+#### Protobuf Schema Provider
+```java
+public interface ProtobufSchemaProvider extends SchemaProvider<Descriptor> {
+    // Inherits schemaFor methods with Descriptor return type
+}
+```
+
+#### Avro Schema Provider
+```java
+public interface AvroSchemaProvider extends SchemaProvider<org.apache.avro.Schema> {
+    // Inherits schemaFor methods with Avro Schema return type
+}
+```
+
+#### JSON Schema Provider
+```java
+public interface JsonSchemaProvider extends SchemaProvider<JsonNode> {
+    // Inherits schemaFor methods with JsonNode return type
+}
+```
+
+### Adapter Integration Pattern
+
+#### Updated Interceptor Pattern
+```java
+public class KafkaGdprAwareProducerInterceptor<K, V> {
+    private SchemaProvider<S> schemaProvider;
+    private PersonalMetadataProvider<V> metadataProvider;
+    
+    @Override
+    public ProducerRecord<K, V> onSend(ProducerRecord<K, V> record) {
+        if (record.value() == null) return record;
+        
+        // Step 1: Discover schema definition
+        S schema = schemaProvider.schemaFor(record.value());
+        
+        // Step 2: Analyze schema for PII metadata
+        PersonalMetadata<V> metadata = metadataProvider.forSchema(schema);
+        
+        // Step 3: Perform encryption
+        V encryptedValue = metadata.swapToEncrypted(encryptor, record.value());
+        
+        return new ProducerRecord<>(/*...*/);
+    }
+}
+```
+
+## 5. Acceptance Criteria
+
+- **AC-001**: Given a business object, When SchemaProvider.schemaFor() is called, Then it returns the appropriate schema definition without performing PII analysis
+- **AC-002**: Given a schema definition, When PersonalMetadataProvider.forSchema() is called, Then it returns PersonalMetadata with identified PII fields
+- **AC-003**: Given an adapter configuration, When both schema and metadata providers are configured, Then they work together to process PII data correctly
+- **AC-004**: Given a Kafka consumer scenario, When schema ID is provided, Then schema provider retrieves correct schema from registry
+- **AC-005**: Given a Kafka producer scenario, When business object is provided, Then schema provider discovers appropriate schema definition
+
+## 6. Test Automation Strategy
+
+### Unit Testing
+- **SchemaProvider implementations**: Test schema discovery for various business object types
+- **PersonalMetadataProvider implementations**: Test PII analysis with provided schema definitions
+- **Mock schema definitions**: Test metadata providers with controlled schema inputs
+
+### Integration Testing
+- **Adapter orchestration**: Test complete flow from business object to encrypted data
+- **Schema registry integration**: Test Kafka scenarios with actual schema registry
+- **Cross-provider compatibility**: Test schema definitions work across different metadata providers
+
+### Performance Testing
+- **Schema caching**: Verify schema discovery performance with caching enabled
+- **Memory allocation**: Monitor object creation during schema and metadata operations
+- **Concurrent access**: Test thread safety of provider implementations
+
+## 7. Rationale & Context
+
+### Design Decisions
+
+**Separation of Schema Discovery and PII Analysis**: This separation allows for better testability, reusability, and maintainability. Schema definitions can be shared and reused across multiple PII operations.
+
+**Generic SchemaProvider Interface**: Using generics allows type-safe implementations while maintaining a common contract across different schema formats.
+
+**Adapter Orchestration**: Moving orchestration logic to adapters keeps providers focused on their specific responsibilities.
+
+### Migration Strategy
+
+The transition will be clean and direct:
+1. Implement new schema provider interfaces for each technology (Protobuf, Avro, JSON Schema)
+2. Add `forSchema()` methods to metadata providers as the sole metadata creation method
+3. Update adapters to use the new orchestration pattern
+4. Update documentation and examples to reflect the clean separation of concerns
+
+## 8. Dependencies & External Integrations
+
+### Infrastructure Dependencies
+- **INF-001**: pi2schema schema-spi - Core SPI interfaces and abstractions
+- **INF-002**: pi2schema crypto-spi - Cryptographic operations interface
+- **INF-003**: Schema format libraries - Protobuf, Avro, Jackson for schema handling
+
+### External Systems
+- **EXT-001**: Kafka Schema Registry - Schema storage and versioning for Kafka adapters
+- **EXT-002**: Serialization frameworks - Integration points for various data formats
+
+### Technology Platform Dependencies
+- **PLT-001**: Java 17+ - Platform requirement for all implementations
+- **PLT-002**: Apache Kafka - For serialization adapter implementations
+
+## 9. Examples & Edge Cases
+
+### Basic Usage Example
+```java
+// Schema discovery
+ProtobufSchemaProvider schemaProvider = new ProtobufSchemaProvider();
+Descriptor schema = schemaProvider.schemaFor(businessObject);
+
+// PII analysis
+ProtobufPersonalMetadataProvider<MyMessage> metadataProvider = 
+    new ProtobufPersonalMetadataProvider<>();
+PersonalMetadata<MyMessage> metadata = metadataProvider.forSchema(schema);
+
+// Encryption
+MyMessage encrypted = metadata.swapToEncrypted(encryptor, businessObject);
+```
+
+### Kafka Adapter Example
+```java
+public class KafkaAdapter {
+    private final JsonSchemaProvider schemaProvider;
+    private final JsonSchemaPersonalMetadataProvider<Map> metadataProvider;
+    
+    public Object process(Object businessObject) {
+        JsonNode schema = schemaProvider.schemaFor(businessObject);
+        PersonalMetadata<Map> metadata = metadataProvider.forSchema(schema);
+        return metadata.swapToEncrypted(encryptor, businessObject);
+    }
+}
+```
+
+### Edge Cases
+- **Unknown schema format**: SchemaProvider should throw SchemaNotFoundException
+- **Unsupported business object**: Provider should fail fast with clear error message
+- **Null schema definition**: PersonalMetadataProvider should handle gracefully
+- **Schema registry unavailable**: Kafka providers should implement appropriate fallback behavior
+
+## 10. Validation Criteria
+
+- All new schema provider implementations implement `SchemaProvider<S>` interface
+- All metadata providers support `forSchema(S schema)` method
+- Existing functionality remains intact through deprecated method support
+- Performance metrics show no regression in schema discovery or PII processing
+- Adapters successfully orchestrate schema and metadata provider interactions
+- Documentation clearly explains the new architecture and migration path
+
+## 11. Related Specifications / Further Reading
+
+- [Schema Definition Provider - Protobuf Implementation](spec-schema-definition-provider-protobuf.md)
+- [Schema Definition Provider - Avro Implementation](spec-schema-definition-provider-avro.md)
+- [Schema Definition Provider - JSON Schema Implementation](spec-schema-definition-provider-jsonschema.md)
+- [Pi2Schema SPI Architecture Documentation](../schema-spi/README.md)
+- [Kafka Serialization Adapters Integration](../serialization-adapters-kafka/README.md)


### PR DESCRIPTION
- Added JSON Schema Definition Provider implementation for schema discovery and PII metadata analysis.
- Introduced Local Protobuf Schema Definition Provider for local-only descriptor extraction.
- Established a clear architecture for Schema Definition Providers, separating schema retrieval from PII analysis.
- Enhanced JSON Schema Personal Metadata Provider to work with separate schema providers and support PII field identification.
- Updated documentation to reflect new implementations, architectural changes, and usage examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded specification file naming guidance with a dedicated “File Naming Convention” section and final reminder.
  - Introduced a comprehensive architecture spec for Schema Definition Providers, covering SPI interfaces and adapter orchestration.
  - Added new specs for Avro and Protobuf local schema providers and a JSON Schema provider with registry-aware discovery.
  - Updated JSON Schema personal metadata provider design to a schema-based entry point, with migration guidance, acceptance criteria, and test strategies.
  - Clarified best practices for specification architecture and separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->