### PR TITLE
refactor: update PersonalMetadataProvider to use schema definitions

### DIFF
--- a/schema-providers-avro/src/main/java/pi2schema/schema/providers/avro/AvroSchemaProvider.java
+++ b/schema-providers-avro/src/main/java/pi2schema/schema/providers/avro/AvroSchemaProvider.java
@@ -1,0 +1,11 @@
+package pi2schema.schema.providers.avro;
+
+import org.apache.avro.Schema;
+import pi2schema.schema.SchemaProvider;
+
+/**
+ * Avro schema provider SPI.
+ */
+public interface AvroSchemaProvider extends SchemaProvider<Schema> {
+    // Inherits schemaFor methods with Avro Schema return type
+}

--- a/schema-providers-avro/src/main/java/pi2schema/schema/providers/avro/personaldata/AvroPersonalMetadataProvider.java
+++ b/schema-providers-avro/src/main/java/pi2schema/schema/providers/avro/personaldata/AvroPersonalMetadataProvider.java
@@ -1,5 +1,6 @@
 package pi2schema.schema.providers.avro.personaldata;
 
+import org.apache.avro.Schema;
 import org.apache.avro.specific.SpecificRecordBase;
 import pi2schema.schema.personaldata.PersonalMetadata;
 import pi2schema.schema.personaldata.PersonalMetadataProvider;
@@ -9,12 +10,11 @@ import java.util.Collections;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
 
-public class AvroPersonalMetadataProvider<T extends SpecificRecordBase> implements PersonalMetadataProvider<T> {
+public class AvroPersonalMetadataProvider<T extends SpecificRecordBase> implements PersonalMetadataProvider<T, Schema> {
 
     @Override
-    public PersonalMetadata<T> forType(T originalObject) {
+    public PersonalMetadata<T> forSchema(Schema schema) {
         //avro union strategy
-        var schema = originalObject.getSchema();
         var personalDataFieldDefinitions = schema
             .getFields()
             .stream()
@@ -23,5 +23,11 @@ public class AvroPersonalMetadataProvider<T extends SpecificRecordBase> implemen
             .collect(collectingAndThen(toList(), Collections::unmodifiableList));
 
         return new AvroPersonalMetadata<>(personalDataFieldDefinitions);
+    }
+
+    @Override
+    @Deprecated
+    public PersonalMetadata<T> forType(T originalObject) {
+        return forSchema(originalObject.getSchema());
     }
 }

--- a/schema-providers-jsonschema/src/main/java/pi2schema/schema/providers/jsonschema/personaldata/JsonSchemaPersonalMetadataProvider.java
+++ b/schema-providers-jsonschema/src/main/java/pi2schema/schema/providers/jsonschema/personaldata/JsonSchemaPersonalMetadataProvider.java
@@ -21,7 +21,7 @@ import static pi2schema.schema.providers.jsonschema.personaldata.JsonPersonalDat
  * Provides PII metadata for business objects based on schema analysis.
  * Simplified to directly handle schema analysis and field definition creation.
  */
-public class JsonSchemaPersonalMetadataProvider<T> implements PersonalMetadataProvider<T> {
+public class JsonSchemaPersonalMetadataProvider<T> implements PersonalMetadataProvider<T, JsonNode> {
 
     private final Map<String, JsonPersonalMetadata<T>> metadataCache;
     private final JsonSiblingSubjectIdentifierFinder subjectIdentifierFinder = new JsonSiblingSubjectIdentifierFinder();

--- a/schema-providers-protobuf/src/main/java/pi2schema/schema/providers/protobuf/ProtobufSchemaProvider.java
+++ b/schema-providers-protobuf/src/main/java/pi2schema/schema/providers/protobuf/ProtobufSchemaProvider.java
@@ -1,0 +1,11 @@
+package pi2schema.schema.providers.protobuf;
+
+import com.google.protobuf.Descriptors.Descriptor;
+import pi2schema.schema.SchemaProvider;
+
+/**
+ * Protobuf schema provider SPI.
+ */
+public interface ProtobufSchemaProvider extends SchemaProvider<Descriptor> {
+    // Inherits schemaFor methods with Descriptor return type
+}

--- a/schema-providers-protobuf/src/main/java/pi2schema/schema/providers/protobuf/personaldata/ProtobufPersonalMetadataProvider.java
+++ b/schema-providers-protobuf/src/main/java/pi2schema/schema/providers/protobuf/personaldata/ProtobufPersonalMetadataProvider.java
@@ -12,18 +12,14 @@ import java.util.Collections;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
 
-public class ProtobufPersonalMetadataProvider<T extends Message> implements PersonalMetadataProvider<T> {
+public class ProtobufPersonalMetadataProvider<T extends Message> implements PersonalMetadataProvider<T, Descriptor> {
 
     private final SiblingSubjectIdentifierFinder subjectIdentifierFinder = new SiblingSubjectIdentifierFinder();
 
     @Override
-    public PersonalMetadata<T> forType(T originalObject) {
-        return forDescriptor(originalObject.getDescriptorForType());
-    }
-
-    public ProtobufPersonalMetadata<T> forDescriptor(Descriptor descriptorForType) {
+    public PersonalMetadata<T> forSchema(Descriptor schema) {
         //protobuf oneOf strategy
-        var personalDataFieldDefinitions = descriptorForType
+        var personalDataFieldDefinitions = schema
             .getOneofs()
             .stream()
             .filter(OneOfPersonalDataFieldDefinition::hasPersonalData)
@@ -31,6 +27,11 @@ public class ProtobufPersonalMetadataProvider<T extends Message> implements Pers
             .collect(collectingAndThen(toList(), Collections::unmodifiableList));
 
         return new ProtobufPersonalMetadata<>(personalDataFieldDefinitions);
+    }
+
+    @Override
+    public PersonalMetadata<T> forType(T originalObject) {
+        return forSchema(originalObject.getDescriptorForType());
     }
 
     private OneOfPersonalDataFieldDefinition createFieldDefinition(Descriptors.OneofDescriptor descriptor) {

--- a/schema-providers-protobuf/src/test/java/pi2schema/schema/providers/protobuf/personaldata/ProtobufProtobufPersonalMetadataProviderTest.java
+++ b/schema-providers-protobuf/src/test/java/pi2schema/schema/providers/protobuf/personaldata/ProtobufProtobufPersonalMetadataProviderTest.java
@@ -21,7 +21,7 @@ class ProtobufProtobufPersonalMetadataProviderTest {
     void givenADescriptorWithoutOneOfThenOptionalEmpty() {
         var descriptorWithoutOneOf = FruitFixture.waterMelon().build().getDescriptorForType();
 
-        var metadata = protobufPersonalMetadataProvider.forDescriptor(descriptorWithoutOneOf);
+        var metadata = protobufPersonalMetadataProvider.forSchema(descriptorWithoutOneOf);
 
         assertThat(metadata.requiresEncryption()).isFalse();
     }
@@ -34,7 +34,7 @@ class ProtobufProtobufPersonalMetadataProviderTest {
             .build()
             .getDescriptorForType();
 
-        var metadata = protobufPersonalMetadataProvider.forDescriptor(descriptorWithOneOf);
+        var metadata = protobufPersonalMetadataProvider.forSchema(descriptorWithOneOf);
 
         assertThat(metadata.requiresEncryption()).isFalse();
     }
@@ -43,7 +43,7 @@ class ProtobufProtobufPersonalMetadataProviderTest {
     void givenADescriptorWithOneOfWithPersonalDataAsSiblingThenPersonalMetadata() {
         var descriptor = FarmerRegisteredEventFixture.johnDoe().build().getDescriptorForType();
 
-        var metadata = protobufPersonalMetadataProvider.forDescriptor(descriptor);
+        var metadata = protobufPersonalMetadataProvider.forSchema(descriptor);
 
         assertThat(metadata.requiresEncryption()).isTrue();
     }

--- a/schema-spi/src/main/java/pi2schema/schema/personaldata/PersonalMetadataProvider.java
+++ b/schema-spi/src/main/java/pi2schema/schema/personaldata/PersonalMetadataProvider.java
@@ -1,12 +1,24 @@
 package pi2schema.schema.personaldata;
 
 /**
- * Generates the @PersonalMetadata abstraction for a given original object.
- * Implementations are intended to be able to encapsulate the retrieval the schema from
- * the original object.
+ * Generates the @PersonalMetadata abstraction for a given schema definition.
+ * Implementations should analyze the provided schema to identify PII fields.
  *
  * @param <T> original object type.
+ * @param <S> schema definition type.
  */
-public interface PersonalMetadataProvider<T> {
+public interface PersonalMetadataProvider<T, S> {
+    /**
+     * Creates PersonalMetadata for a given schema definition.
+     * This is the method for schema-based providers.
+     * @param schema The schema definition to analyze
+     * @return PersonalMetadata containing PII field definitions
+     */
+    PersonalMetadata<T> forSchema(S schema);
+
+    /**
+     * @deprecated Use {@link #forSchema(Object)} instead. This method will be removed in future versions.
+     */
+    @Deprecated
     PersonalMetadata<T> forType(T originalObject);
 }

--- a/serialization-adapters-kafka/src/main/java/pi2schema/serialization/kafka/KafkaGdprAwareConsumerInterceptor.java
+++ b/serialization-adapters-kafka/src/main/java/pi2schema/serialization/kafka/KafkaGdprAwareConsumerInterceptor.java
@@ -20,7 +20,7 @@ public final class KafkaGdprAwareConsumerInterceptor<K, V> implements ConsumerIn
 
     private DecryptingMaterialsProvider materialsProvider;
     private LocalDecryptor decryptor;
-    private PersonalMetadataProvider<V> metadataProvider;
+    private PersonalMetadataProvider<V, ?> metadataProvider;
 
     @Override
     public ConsumerRecords<K, V> onConsume(ConsumerRecords<K, V> records) {

--- a/serialization-adapters-kafka/src/main/java/pi2schema/serialization/kafka/KafkaGdprAwareProducerInterceptor.java
+++ b/serialization-adapters-kafka/src/main/java/pi2schema/serialization/kafka/KafkaGdprAwareProducerInterceptor.java
@@ -18,7 +18,7 @@ public final class KafkaGdprAwareProducerInterceptor<K, V> implements ProducerIn
     private EncryptingMaterialsProvider materialsProvider;
     private LocalEncryptor localEncryptor;
 
-    private PersonalMetadataProvider<V> metadataProvider;
+    private PersonalMetadataProvider<V, ?> metadataProvider;
 
     @Override
     public ProducerRecord<K, V> onSend(ProducerRecord<K, V> record) {


### PR DESCRIPTION
This MR just adjusts the MetadataProviders to already receive the schema, instead of infering the schema itself.

this is important because especially in json, is important to infer the schema from the remote/registry.

Current interfaces are empty but ideally it will hold the forType() current implementation and this responsibility will be removed from MetadataProviders.

This focus on the spi mostly, so `spec/spec-schema-definition-provider.md` in order to make small prs.

In order to have this feature fully complete the other 3 specs for each provider have to be implemented, in follow up prs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced schema-driven personal data metadata across providers (Avro, Protobuf, JSON Schema).
  - Added dedicated schema provider interfaces for Avro and Protobuf.

- Refactor
  - Unified providers to accept explicit schema inputs rather than inferring from objects.
  - Aligned JSON Schema provider with the new generic type pattern.

- Deprecations
  - Object-based metadata entry points are deprecated in favor of schema-based usage (backward-compatible wrappers provided).

- Tests
  - Updated tests to cover schema-driven workflows.

- Chores
  - Internal type generalizations in Kafka interceptors without public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->