### PR TITLE
Refactor Vault crypto provider tests to use AssertJ and var

### DIFF
--- a/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/InvalidEncryptionContextExceptionTest.java
+++ b/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/InvalidEncryptionContextExceptionTest.java
@@ -3,81 +3,67 @@ package pi2schema.crypto.providers.vault;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class InvalidEncryptionContextExceptionTest {
 
     @Test
     @DisplayName("Should create invalid encryption context exception with context and message")
     void shouldCreateInvalidEncryptionContextExceptionWithContextAndMessage() {
-        String encryptionContext = "invalid-context";
-        String message = "Invalid encryption context format";
-        InvalidEncryptionContextException exception = new InvalidEncryptionContextException(encryptionContext, message);
+        var encryptionContext = "invalid-context";
+        var message = "Invalid encryption context format";
+        var exception = new InvalidEncryptionContextException(encryptionContext, message);
 
-        assertEquals(message, exception.getMessage());
-        assertEquals(encryptionContext, exception.getEncryptionContext());
-        assertNull(exception.getCause());
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getEncryptionContext()).isEqualTo(encryptionContext);
+        assertThat(exception.getCause()).isNull();
     }
 
     @Test
     @DisplayName("Should create invalid encryption context exception with context, message and cause")
     void shouldCreateInvalidEncryptionContextExceptionWithContextMessageAndCause() {
-        String encryptionContext = "invalid-context";
-        String message = "Invalid encryption context format";
-        Throwable cause = new RuntimeException("Parse error");
-        InvalidEncryptionContextException exception = new InvalidEncryptionContextException(
-            encryptionContext,
-            message,
-            cause
-        );
+        var encryptionContext = "invalid-context";
+        var message = "Invalid encryption context format";
+        var cause = new RuntimeException("Parse error");
+        var exception = new InvalidEncryptionContextException(encryptionContext, message, cause);
 
-        assertEquals(message, exception.getMessage());
-        assertEquals(encryptionContext, exception.getEncryptionContext());
-        assertEquals(cause, exception.getCause());
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getEncryptionContext()).isEqualTo(encryptionContext);
+        assertThat(exception.getCause()).isEqualTo(cause);
     }
 
     @Test
     @DisplayName("Should preserve encryption context in exception")
     void shouldPreserveEncryptionContextInException() {
-        String encryptionContext = "subjectId=user-123;timestamp=invalid";
-        InvalidEncryptionContextException exception = new InvalidEncryptionContextException(
-            encryptionContext,
-            "Test message"
-        );
+        var encryptionContext = "subjectId=user-123;timestamp=invalid";
+        var exception = new InvalidEncryptionContextException(encryptionContext, "Test message");
 
-        assertEquals(encryptionContext, exception.getEncryptionContext());
+        assertThat(exception.getEncryptionContext()).isEqualTo(encryptionContext);
     }
 
     @Test
     @DisplayName("Should handle null encryption context")
     void shouldHandleNullEncryptionContext() {
-        InvalidEncryptionContextException exception = new InvalidEncryptionContextException(null, "Test message");
+        var exception = new InvalidEncryptionContextException(null, "Test message");
 
-        assertNull(exception.getEncryptionContext());
-        assertEquals("Test message", exception.getMessage());
+        assertThat(exception.getEncryptionContext()).isNull();
+        assertThat(exception.getMessage()).isEqualTo("Test message");
     }
 
     @Test
     @DisplayName("Should handle empty encryption context")
     void shouldHandleEmptyEncryptionContext() {
-        String encryptionContext = "";
-        InvalidEncryptionContextException exception = new InvalidEncryptionContextException(
-            encryptionContext,
-            "Test message"
-        );
+        var encryptionContext = "";
+        var exception = new InvalidEncryptionContextException(encryptionContext, "Test message");
 
-        assertEquals(encryptionContext, exception.getEncryptionContext());
-        assertEquals("Test message", exception.getMessage());
+        assertThat(exception.getEncryptionContext()).isEqualTo(encryptionContext);
+        assertThat(exception.getMessage()).isEqualTo("Test message");
     }
 
     @Test
     @DisplayName("Should be instance of VaultCryptoException")
     void shouldBeInstanceOfVaultCryptoException() {
-        InvalidEncryptionContextException exception = new InvalidEncryptionContextException(
-            "invalid-context",
-            "Test message"
-        );
-        assertInstanceOf(VaultCryptoException.class, exception);
-        assertInstanceOf(RuntimeException.class, exception);
+        var exception = new InvalidEncryptionContextException("invalid-context", "Test message");
+        assertThat(exception).isInstanceOf(VaultCryptoException.class).isInstanceOf(RuntimeException.class);
     }
 }

--- a/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/SubjectKeyNotFoundExceptionTest.java
+++ b/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/SubjectKeyNotFoundExceptionTest.java
@@ -3,58 +3,57 @@ package pi2schema.crypto.providers.vault;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class SubjectKeyNotFoundExceptionTest {
 
     @Test
     @DisplayName("Should create subject key not found exception with subject ID and message")
     void shouldCreateSubjectKeyNotFoundExceptionWithSubjectIdAndMessage() {
-        String subjectId = "user-123";
-        String message = "Key not found for subject";
-        SubjectKeyNotFoundException exception = new SubjectKeyNotFoundException(subjectId, message);
+        var subjectId = "user-123";
+        var message = "Key not found for subject";
+        var exception = new SubjectKeyNotFoundException(subjectId, message);
 
-        assertEquals(message, exception.getMessage());
-        assertEquals(subjectId, exception.getSubjectId());
-        assertNull(exception.getCause());
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getSubjectId()).isEqualTo(subjectId);
+        assertThat(exception.getCause()).isNull();
     }
 
     @Test
     @DisplayName("Should create subject key not found exception with subject ID, message and cause")
     void shouldCreateSubjectKeyNotFoundExceptionWithSubjectIdMessageAndCause() {
-        String subjectId = "user-123";
-        String message = "Key not found for subject";
-        Throwable cause = new RuntimeException("Vault key missing");
-        SubjectKeyNotFoundException exception = new SubjectKeyNotFoundException(subjectId, message, cause);
+        var subjectId = "user-123";
+        var message = "Key not found for subject";
+        var cause = new RuntimeException("Vault key missing");
+        var exception = new SubjectKeyNotFoundException(subjectId, message, cause);
 
-        assertEquals(message, exception.getMessage());
-        assertEquals(subjectId, exception.getSubjectId());
-        assertEquals(cause, exception.getCause());
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getSubjectId()).isEqualTo(subjectId);
+        assertThat(exception.getCause()).isEqualTo(cause);
     }
 
     @Test
     @DisplayName("Should preserve subject ID in exception")
     void shouldPreserveSubjectIdInException() {
-        String subjectId = "user-456";
-        SubjectKeyNotFoundException exception = new SubjectKeyNotFoundException(subjectId, "Test message");
+        var subjectId = "user-456";
+        var exception = new SubjectKeyNotFoundException(subjectId, "Test message");
 
-        assertEquals(subjectId, exception.getSubjectId());
+        assertThat(exception.getSubjectId()).isEqualTo(subjectId);
     }
 
     @Test
     @DisplayName("Should handle null subject ID")
     void shouldHandleNullSubjectId() {
-        SubjectKeyNotFoundException exception = new SubjectKeyNotFoundException(null, "Test message");
+        var exception = new SubjectKeyNotFoundException(null, "Test message");
 
-        assertNull(exception.getSubjectId());
-        assertEquals("Test message", exception.getMessage());
+        assertThat(exception.getSubjectId()).isNull();
+        assertThat(exception.getMessage()).isEqualTo("Test message");
     }
 
     @Test
     @DisplayName("Should be instance of VaultCryptoException")
     void shouldBeInstanceOfVaultCryptoException() {
-        SubjectKeyNotFoundException exception = new SubjectKeyNotFoundException("user-123", "Test message");
-        assertInstanceOf(VaultCryptoException.class, exception);
-        assertInstanceOf(RuntimeException.class, exception);
+        var exception = new SubjectKeyNotFoundException("user-123", "Test message");
+        assertThat(exception).isInstanceOf(VaultCryptoException.class).isInstanceOf(RuntimeException.class);
     }
 }

--- a/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultAuthenticationErrorHandlingTest.java
+++ b/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultAuthenticationErrorHandlingTest.java
@@ -11,12 +11,11 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for authentication and authorization error handling scenarios.
@@ -57,9 +56,7 @@ class VaultAuthenticationErrorHandlingTest {
     @DisplayName("Should handle invalid token format with proper error logging")
     void shouldHandleInvalidTokenFormatWithProperErrorLogging() {
         // When/Then - should fail during configuration building with empty token
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> {
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com:8200")
@@ -70,66 +67,33 @@ class VaultAuthenticationErrorHandlingTest {
                     .requestTimeout(Duration.ofSeconds(10))
                     .maxRetries(1)
                     .retryBackoffMs(Duration.ofMillis(100))
-                    .build();
-            }
-        );
-
-        assertTrue(exception.getMessage().contains("Vault token cannot be null or empty"));
+                    .build()
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Vault token cannot be null or empty");
     }
 
     @Test
     @DisplayName("Should handle token with whitespace with proper error logging")
     void shouldHandleTokenWithWhitespaceWithProperErrorLogging() {
         // Given - configuration with token containing whitespace
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> {
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com:8200")
                     .vaultToken("  token-with-spaces  ") // Token with leading/trailing spaces
                     .transitEnginePath("transit")
                     .keyPrefix("test-prefix")
-                    .build();
-            }
-        );
-
-        assertTrue(exception.getMessage().contains("Vault token cannot contain leading or trailing whitespace"));
-    }
-
-    @Test
-    @DisplayName("Should not retry authentication failures")
-    void shouldNotRetryAuthenticationFailures() {
-        // This test simulates what would happen with a 401/403 response
-        // Since we can't easily mock HTTP responses in this test, we'll test the retry logic directly
-
-        VaultCryptoConfiguration config = VaultCryptoConfiguration
-            .builder()
-            .vaultUrl("https://vault.example.com:8200")
-            .vaultToken("invalid-token-format")
-            .transitEnginePath("transit")
-            .keyPrefix("test-prefix")
-            .connectionTimeout(Duration.ofSeconds(1))
-            .requestTimeout(Duration.ofSeconds(2))
-            .maxRetries(3)
-            .retryBackoffMs(Duration.ofMillis(100))
-            .build();
-
-        VaultTransitClient client = new VaultTransitClient(config);
-
-        // Test the retry logic with authentication exception
-        VaultAuthenticationException authException = new VaultAuthenticationException("Invalid token");
-
-        // Verify that authentication exceptions are not retryable
-        // This is tested indirectly through the isRetryableException method behavior
-
-        client.close();
+                    .build()
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Vault token cannot contain leading or trailing whitespace");
     }
 
     @Test
     @DisplayName("Should log authentication failures without exposing token")
     void shouldLogAuthenticationFailuresWithoutExposingToken() {
-        VaultCryptoConfiguration config = VaultCryptoConfiguration
+        var config = VaultCryptoConfiguration
             .builder()
             .vaultUrl("https://vault.example.com:8200")
             .vaultToken("secret-token-12345")
@@ -141,70 +105,53 @@ class VaultAuthenticationErrorHandlingTest {
             .retryBackoffMs(Duration.ofMillis(50))
             .build();
 
-        VaultEncryptingMaterialsProvider provider = new VaultEncryptingMaterialsProvider(config);
+        try (var provider = new VaultEncryptingMaterialsProvider(config)) {
+            // When - this will fail due to network issues, but we can verify token is not logged
+            var future = provider.encryptionKeysFor("test-subject");
 
-        // When - this will fail due to network issues, but we can verify token is not logged
-        CompletableFuture<pi2schema.crypto.providers.EncryptionMaterial> future = provider.encryptionKeysFor(
-            "test-subject"
-        );
+            assertThatThrownBy(() -> future.get(3, TimeUnit.SECONDS)).isInstanceOf(ExecutionException.class);
 
-        assertThrows(
-            ExecutionException.class,
-            () -> {
-                future.get(3, TimeUnit.SECONDS);
-            }
-        );
+            // Then - verify token is not in any log messages
+            var allLogs = logAppender.list;
 
-        // Then - verify token is not in any log messages
-        List<ILoggingEvent> allLogs = logAppender.list;
-
-        allLogs.forEach(event -> {
-            String message = event.getFormattedMessage();
-            assertFalse(message.contains("secret-token-12345"), "Should not log vault token: " + message);
-        });
-
-        provider.close();
+            allLogs.forEach(event -> {
+                var message = event.getFormattedMessage();
+                assertThat(message).doesNotContain("secret-token-12345");
+            });
+        }
     }
 
     @Test
     @DisplayName("Should handle configuration validation for URL format")
     void shouldHandleConfigurationValidationForUrlFormat() {
         // Test invalid URL schemes
-        IllegalArgumentException exception1 = assertThrows(
-            IllegalArgumentException.class,
-            () -> {
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("ftp://vault.example.com:8200") // Invalid scheme
                     .vaultToken("token")
-                    .build();
-            }
-        );
-
-        assertTrue(exception1.getMessage().contains("Vault URL must start with http:// or https://"));
+                    .build()
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Vault URL must start with http:// or https://");
 
         // Test missing scheme
-        IllegalArgumentException exception2 = assertThrows(
-            IllegalArgumentException.class,
-            () -> {
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("vault.example.com:8200") // Missing scheme
                     .vaultToken("token")
-                    .build();
-            }
-        );
-
-        assertTrue(exception2.getMessage().contains("Vault URL must start with http:// or https://"));
+                    .build()
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Vault URL must start with http:// or https://");
     }
 
     @Test
     @DisplayName("Should handle configuration validation for key prefix")
     void shouldHandleConfigurationValidationForKeyPrefix() {
         // Test invalid characters in key prefix
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> {
+        assertThatThrownBy(() ->
                 new VaultEncryptingMaterialsProvider(
                     VaultCryptoConfiguration
                         .builder()
@@ -212,20 +159,17 @@ class VaultAuthenticationErrorHandlingTest {
                         .vaultToken("token")
                         .keyPrefix("invalid@prefix!") // Invalid characters
                         .build()
-                );
-            }
-        );
-
-        assertTrue(exception.getMessage().contains("Key prefix can only contain alphanumeric characters"));
+                )
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Key prefix can only contain alphanumeric characters");
     }
 
     @Test
     @DisplayName("Should handle configuration validation for timeout values")
     void shouldHandleConfigurationValidationForTimeoutValues() {
         // Test excessive connection timeout
-        IllegalArgumentException exception1 = assertThrows(
-            IllegalArgumentException.class,
-            () -> {
+        assertThatThrownBy(() ->
                 new VaultEncryptingMaterialsProvider(
                     VaultCryptoConfiguration
                         .builder()
@@ -233,16 +177,13 @@ class VaultAuthenticationErrorHandlingTest {
                         .vaultToken("token")
                         .connectionTimeout(Duration.ofMinutes(10)) // Too long
                         .build()
-                );
-            }
-        );
-
-        assertTrue(exception1.getMessage().contains("Connection timeout cannot exceed 5 minutes"));
+                )
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Connection timeout cannot exceed 5 minutes");
 
         // Test excessive request timeout
-        IllegalArgumentException exception2 = assertThrows(
-            IllegalArgumentException.class,
-            () -> {
+        assertThatThrownBy(() ->
                 new VaultEncryptingMaterialsProvider(
                     VaultCryptoConfiguration
                         .builder()
@@ -250,42 +191,31 @@ class VaultAuthenticationErrorHandlingTest {
                         .vaultToken("token")
                         .requestTimeout(Duration.ofMinutes(15)) // Too long
                         .build()
-                );
-            }
-        );
-
-        assertTrue(exception2.getMessage().contains("Request timeout cannot exceed 10 minutes"));
+                )
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Request timeout cannot exceed 10 minutes");
     }
 
     @Test
     @DisplayName("Should provide clear error messages for configuration issues")
     void shouldProvideClearErrorMessagesForConfigurationIssues() {
         // Test null configuration
-        IllegalArgumentException exception1 = assertThrows(
-            IllegalArgumentException.class,
-            () -> {
-                new VaultEncryptingMaterialsProvider(null);
-            }
-        );
-
-        assertEquals("Configuration cannot be null", exception1.getMessage());
+        assertThatThrownBy(() -> new VaultEncryptingMaterialsProvider(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Configuration cannot be null");
 
         // Test null configuration for decrypting provider
-        IllegalArgumentException exception2 = assertThrows(
-            IllegalArgumentException.class,
-            () -> {
-                new VaultDecryptingMaterialsProvider(null);
-            }
-        );
-
-        assertEquals("Configuration cannot be null", exception2.getMessage());
+        assertThatThrownBy(() -> new VaultDecryptingMaterialsProvider(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Configuration cannot be null");
     }
 
     @Test
     @DisplayName("Should log configuration validation success")
     void shouldLogConfigurationValidationSuccess() {
         // Given - valid configuration
-        VaultCryptoConfiguration config = VaultCryptoConfiguration
+        var config = VaultCryptoConfiguration
             .builder()
             .vaultUrl("https://vault.example.com:8200")
             .vaultToken("valid-token")
@@ -298,26 +228,18 @@ class VaultAuthenticationErrorHandlingTest {
             .build();
 
         // When
-        VaultEncryptingMaterialsProvider provider = new VaultEncryptingMaterialsProvider(config);
+        try (var provider = new VaultEncryptingMaterialsProvider(config)) {
+            // Then - verify successful initialization is logged
+            var debugLogs = logAppender.list.stream().filter(event -> event.getLevel() == Level.DEBUG).toList();
 
-        // Then - verify successful initialization is logged
-        List<ILoggingEvent> debugLogs = logAppender.list
-            .stream()
-            .filter(event -> event.getLevel() == Level.DEBUG)
-            .toList();
-
-        assertTrue(
-            debugLogs.stream().anyMatch(event -> event.getMessage().contains("Configuration validation successful")),
-            "Should log successful configuration validation"
-        );
-
-        provider.close();
+            assertThat(debugLogs).anyMatch(event -> event.getMessage().contains("Configuration validation successful"));
+        }
     }
 
     @Test
     @DisplayName("Should handle subject ID sanitization logging")
     void shouldHandleSubjectIdSanitizationLogging() {
-        VaultCryptoConfiguration config = VaultCryptoConfiguration
+        var config = VaultCryptoConfiguration
             .builder()
             .vaultUrl("https://vault.example.com:8200")
             .vaultToken("token")
@@ -325,29 +247,19 @@ class VaultAuthenticationErrorHandlingTest {
             .keyPrefix("test-prefix")
             .build();
 
-        VaultTransitClient client = new VaultTransitClient(config);
+        try (var client = new VaultTransitClient(config)) {
+            // When - generate key name with special characters that need sanitization
+            var keyName = client.generateKeyName("user@domain.com/special#chars");
 
-        // When - generate key name with special characters that need sanitization
-        String keyName = client.generateKeyName("user@domain.com/special#chars");
+            // Then - verify sanitization occurred and was logged
+            var subjectPart = keyName.substring(keyName.lastIndexOf("_") + 1);
+            assertThat(subjectPart).doesNotContain("@", "#");
+            assertThat(keyName).contains("test-prefix_subject_");
 
-        // Then - verify sanitization occurred and was logged
-        // The keyName should not contain the original special characters in the subject part
-        String subjectPart = keyName.substring(keyName.lastIndexOf("_") + 1);
-        assertFalse(subjectPart.contains("@"), "Subject part should not contain @");
-        assertFalse(subjectPart.contains("#"), "Subject part should not contain #");
-        assertTrue(keyName.contains("test-prefix_subject_"), "Should contain the expected path structure");
+            // Verify sanitization was logged
+            var debugLogs = logAppender.list.stream().filter(event -> event.getLevel() == Level.DEBUG).toList();
 
-        // Verify sanitization was logged
-        List<ILoggingEvent> debugLogs = logAppender.list
-            .stream()
-            .filter(event -> event.getLevel() == Level.DEBUG)
-            .toList();
-
-        assertTrue(
-            debugLogs.stream().anyMatch(event -> event.getMessage().contains("Subject ID was sanitized")),
-            "Should log subject ID sanitization"
-        );
-
-        client.close();
+            assertThat(debugLogs).anyMatch(event -> event.getMessage().contains("Subject ID was sanitized"));
+        }
     }
 }

--- a/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultAuthenticationExceptionTest.java
+++ b/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultAuthenticationExceptionTest.java
@@ -3,46 +3,45 @@ package pi2schema.crypto.providers.vault;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class VaultAuthenticationExceptionTest {
 
     @Test
     @DisplayName("Should create authentication exception with message")
     void shouldCreateAuthenticationExceptionWithMessage() {
-        String message = "Authentication failed";
-        VaultAuthenticationException exception = new VaultAuthenticationException(message);
+        var message = "Authentication failed";
+        var exception = new VaultAuthenticationException(message);
 
-        assertEquals(message, exception.getMessage());
-        assertNull(exception.getCause());
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getCause()).isNull();
     }
 
     @Test
     @DisplayName("Should create authentication exception with message and cause")
     void shouldCreateAuthenticationExceptionWithMessageAndCause() {
-        String message = "Authentication failed";
-        Throwable cause = new RuntimeException("Invalid token");
-        VaultAuthenticationException exception = new VaultAuthenticationException(message, cause);
+        var message = "Authentication failed";
+        var cause = new RuntimeException("Invalid token");
+        var exception = new VaultAuthenticationException(message, cause);
 
-        assertEquals(message, exception.getMessage());
-        assertEquals(cause, exception.getCause());
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getCause()).isEqualTo(cause);
     }
 
     @Test
     @DisplayName("Should create authentication exception with cause only")
     void shouldCreateAuthenticationExceptionWithCauseOnly() {
-        Throwable cause = new RuntimeException("Invalid token");
-        VaultAuthenticationException exception = new VaultAuthenticationException(cause);
+        var cause = new RuntimeException("Invalid token");
+        var exception = new VaultAuthenticationException(cause);
 
-        assertEquals(cause, exception.getCause());
-        assertTrue(exception.getMessage().contains("RuntimeException"));
+        assertThat(exception.getCause()).isEqualTo(cause);
+        assertThat(exception.getMessage()).contains("RuntimeException");
     }
 
     @Test
     @DisplayName("Should be instance of VaultCryptoException")
     void shouldBeInstanceOfVaultCryptoException() {
-        VaultAuthenticationException exception = new VaultAuthenticationException("Test message");
-        assertInstanceOf(VaultCryptoException.class, exception);
-        assertInstanceOf(RuntimeException.class, exception);
+        var exception = new VaultAuthenticationException("Test message");
+        assertThat(exception).isInstanceOf(VaultCryptoException.class).isInstanceOf(RuntimeException.class);
     }
 }

--- a/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultConnectivityExceptionTest.java
+++ b/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultConnectivityExceptionTest.java
@@ -3,46 +3,45 @@ package pi2schema.crypto.providers.vault;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class VaultConnectivityExceptionTest {
 
     @Test
     @DisplayName("Should create connectivity exception with message")
     void shouldCreateConnectivityExceptionWithMessage() {
-        String message = "Connection timeout";
-        VaultConnectivityException exception = new VaultConnectivityException(message);
+        var message = "Connection timeout";
+        var exception = new VaultConnectivityException(message);
 
-        assertEquals(message, exception.getMessage());
-        assertNull(exception.getCause());
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getCause()).isNull();
     }
 
     @Test
     @DisplayName("Should create connectivity exception with message and cause")
     void shouldCreateConnectivityExceptionWithMessageAndCause() {
-        String message = "Connection timeout";
-        Throwable cause = new RuntimeException("Network unreachable");
-        VaultConnectivityException exception = new VaultConnectivityException(message, cause);
+        var message = "Connection timeout";
+        var cause = new RuntimeException("Network unreachable");
+        var exception = new VaultConnectivityException(message, cause);
 
-        assertEquals(message, exception.getMessage());
-        assertEquals(cause, exception.getCause());
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getCause()).isEqualTo(cause);
     }
 
     @Test
     @DisplayName("Should create connectivity exception with cause only")
     void shouldCreateConnectivityExceptionWithCauseOnly() {
-        Throwable cause = new RuntimeException("Network unreachable");
-        VaultConnectivityException exception = new VaultConnectivityException(cause);
+        var cause = new RuntimeException("Network unreachable");
+        var exception = new VaultConnectivityException(cause);
 
-        assertEquals(cause, exception.getCause());
-        assertTrue(exception.getMessage().contains("RuntimeException"));
+        assertThat(exception.getCause()).isEqualTo(cause);
+        assertThat(exception.getMessage()).contains("RuntimeException");
     }
 
     @Test
     @DisplayName("Should be instance of VaultCryptoException")
     void shouldBeInstanceOfVaultCryptoException() {
-        VaultConnectivityException exception = new VaultConnectivityException("Test message");
-        assertInstanceOf(VaultCryptoException.class, exception);
-        assertInstanceOf(RuntimeException.class, exception);
+        var exception = new VaultConnectivityException("Test message");
+        assertThat(exception).isInstanceOf(VaultCryptoException.class).isInstanceOf(RuntimeException.class);
     }
 }

--- a/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultCryptoConfigurationTest.java
+++ b/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultCryptoConfigurationTest.java
@@ -8,33 +8,33 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 class VaultCryptoConfigurationTest {
 
     @Test
     @DisplayName("Should create configuration with valid parameters")
     void shouldCreateConfigurationWithValidParameters() {
-        VaultCryptoConfiguration config = VaultCryptoConfiguration
+        var config = VaultCryptoConfiguration
             .builder()
             .vaultUrl("https://vault.example.com")
             .vaultToken("test-token")
             .build();
 
-        assertEquals("https://vault.example.com", config.getVaultUrl());
-        assertEquals("test-token", config.getVaultToken());
-        assertEquals("transit", config.getTransitEnginePath());
-        assertEquals("pi2schema", config.getKeyPrefix());
-        assertEquals(Duration.ofSeconds(10), config.getConnectionTimeout());
-        assertEquals(Duration.ofSeconds(30), config.getRequestTimeout());
-        assertEquals(3, config.getMaxRetries());
-        assertEquals(Duration.ofMillis(100), config.getRetryBackoffMs());
+        assertThat(config.getVaultUrl()).isEqualTo("https://vault.example.com");
+        assertThat(config.getVaultToken()).isEqualTo("test-token");
+        assertThat(config.getTransitEnginePath()).isEqualTo("transit");
+        assertThat(config.getKeyPrefix()).isEqualTo("pi2schema");
+        assertThat(config.getConnectionTimeout()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(config.getRequestTimeout()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(config.getMaxRetries()).isEqualTo(3);
+        assertThat(config.getRetryBackoffMs()).isEqualTo(Duration.ofMillis(100));
     }
 
     @Test
     @DisplayName("Should create configuration with custom parameters")
     void shouldCreateConfigurationWithCustomParameters() {
-        VaultCryptoConfiguration config = VaultCryptoConfiguration
+        var config = VaultCryptoConfiguration
             .builder()
             .vaultUrl("https://custom-vault.example.com")
             .vaultToken("custom-token")
@@ -46,14 +46,14 @@ class VaultCryptoConfigurationTest {
             .retryBackoffMs(Duration.ofMillis(200))
             .build();
 
-        assertEquals("https://custom-vault.example.com", config.getVaultUrl());
-        assertEquals("custom-token", config.getVaultToken());
-        assertEquals("custom-transit", config.getTransitEnginePath());
-        assertEquals("custom-prefix", config.getKeyPrefix());
-        assertEquals(Duration.ofSeconds(5), config.getConnectionTimeout());
-        assertEquals(Duration.ofSeconds(60), config.getRequestTimeout());
-        assertEquals(5, config.getMaxRetries());
-        assertEquals(Duration.ofMillis(200), config.getRetryBackoffMs());
+        assertThat(config.getVaultUrl()).isEqualTo("https://custom-vault.example.com");
+        assertThat(config.getVaultToken()).isEqualTo("custom-token");
+        assertThat(config.getTransitEnginePath()).isEqualTo("custom-transit");
+        assertThat(config.getKeyPrefix()).isEqualTo("custom-prefix");
+        assertThat(config.getConnectionTimeout()).isEqualTo(Duration.ofSeconds(5));
+        assertThat(config.getRequestTimeout()).isEqualTo(Duration.ofSeconds(60));
+        assertThat(config.getMaxRetries()).isEqualTo(5);
+        assertThat(config.getRetryBackoffMs()).isEqualTo(Duration.ofMillis(200));
     }
 
     @ParameterizedTest
@@ -61,11 +61,11 @@ class VaultCryptoConfigurationTest {
     @ValueSource(strings = { "", "   " })
     @DisplayName("Should throw exception for invalid vault URL")
     void shouldThrowExceptionForInvalidVaultUrl(String invalidUrl) {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> VaultCryptoConfiguration.builder().vaultUrl(invalidUrl).vaultToken("test-token").build()
-        );
-        assertEquals("Vault URL cannot be null or empty", exception.getMessage());
+        assertThatThrownBy(() ->
+                VaultCryptoConfiguration.builder().vaultUrl(invalidUrl).vaultToken("test-token").build()
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Vault URL cannot be null or empty");
     }
 
     @ParameterizedTest
@@ -73,16 +73,15 @@ class VaultCryptoConfigurationTest {
     @ValueSource(strings = { "", "   " })
     @DisplayName("Should throw exception for invalid vault token")
     void shouldThrowExceptionForInvalidVaultToken(String invalidToken) {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken(invalidToken)
                     .build()
-        );
-        assertEquals("Vault token cannot be null or empty", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Vault token cannot be null or empty");
     }
 
     @ParameterizedTest
@@ -90,17 +89,16 @@ class VaultCryptoConfigurationTest {
     @ValueSource(strings = { "", "   " })
     @DisplayName("Should throw exception for invalid transit engine path")
     void shouldThrowExceptionForInvalidTransitEnginePath(String invalidPath) {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("test-token")
                     .transitEnginePath(invalidPath)
                     .build()
-        );
-        assertEquals("Transit engine path cannot be null or empty", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Transit engine path cannot be null or empty");
     }
 
     @ParameterizedTest
@@ -108,228 +106,220 @@ class VaultCryptoConfigurationTest {
     @ValueSource(strings = { "", "   " })
     @DisplayName("Should throw exception for invalid key prefix")
     void shouldThrowExceptionForInvalidKeyPrefix(String invalidPrefix) {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("test-token")
                     .keyPrefix(invalidPrefix)
                     .build()
-        );
-        assertEquals("Key prefix cannot be null or empty", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Key prefix cannot be null or empty");
     }
 
     @Test
     @DisplayName("Should throw exception for null connection timeout")
     void shouldThrowExceptionForNullConnectionTimeout() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("test-token")
                     .connectionTimeout(null)
                     .build()
-        );
-        assertEquals("Connection timeout must be positive", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Connection timeout must be positive");
     }
 
     @Test
     @DisplayName("Should throw exception for zero connection timeout")
     void shouldThrowExceptionForZeroConnectionTimeout() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("test-token")
                     .connectionTimeout(Duration.ZERO)
                     .build()
-        );
-        assertEquals("Connection timeout must be positive", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Connection timeout must be positive");
     }
 
     @Test
     @DisplayName("Should throw exception for negative connection timeout")
     void shouldThrowExceptionForNegativeConnectionTimeout() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("test-token")
                     .connectionTimeout(Duration.ofSeconds(-1))
                     .build()
-        );
-        assertEquals("Connection timeout must be positive", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Connection timeout must be positive");
     }
 
     @Test
     @DisplayName("Should throw exception for null request timeout")
     void shouldThrowExceptionForNullRequestTimeout() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("test-token")
                     .requestTimeout(null)
                     .build()
-        );
-        assertEquals("Request timeout must be positive", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Request timeout must be positive");
     }
 
     @Test
     @DisplayName("Should throw exception for zero request timeout")
     void shouldThrowExceptionForZeroRequestTimeout() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("test-token")
                     .requestTimeout(Duration.ZERO)
                     .build()
-        );
-        assertEquals("Request timeout must be positive", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Request timeout must be positive");
     }
 
     @Test
     @DisplayName("Should throw exception for negative request timeout")
     void shouldThrowExceptionForNegativeRequestTimeout() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("test-token")
                     .requestTimeout(Duration.ofSeconds(-1))
                     .build()
-        );
-        assertEquals("Request timeout must be positive", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Request timeout must be positive");
     }
 
     @Test
     @DisplayName("Should throw exception for negative max retries")
     void shouldThrowExceptionForNegativeMaxRetries() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("test-token")
                     .maxRetries(-1)
                     .build()
-        );
-        assertEquals("Max retries cannot be negative", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Max retries cannot be negative");
     }
 
     @Test
     @DisplayName("Should allow zero max retries")
     void shouldAllowZeroMaxRetries() {
-        assertDoesNotThrow(() ->
-            VaultCryptoConfiguration
-                .builder()
-                .vaultUrl("https://vault.example.com")
-                .vaultToken("test-token")
-                .maxRetries(0)
-                .build()
-        );
+        assertThatCode(() ->
+                VaultCryptoConfiguration
+                    .builder()
+                    .vaultUrl("https://vault.example.com")
+                    .vaultToken("test-token")
+                    .maxRetries(0)
+                    .build()
+            )
+            .doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("Should throw exception for null retry backoff")
     void shouldThrowExceptionForNullRetryBackoff() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("test-token")
                     .retryBackoffMs(null)
                     .build()
-        );
-        assertEquals("Retry backoff must be non-negative", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Retry backoff must be non-negative");
     }
 
     @Test
     @DisplayName("Should throw exception for negative retry backoff")
     void shouldThrowExceptionForNegativeRetryBackoff() {
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("test-token")
                     .retryBackoffMs(Duration.ofMillis(-1))
                     .build()
-        );
-        assertEquals("Retry backoff must be non-negative", exception.getMessage());
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Retry backoff must be non-negative");
     }
 
     @Test
     @DisplayName("Should allow zero retry backoff")
     void shouldAllowZeroRetryBackoff() {
-        assertDoesNotThrow(() ->
-            VaultCryptoConfiguration
-                .builder()
-                .vaultUrl("https://vault.example.com")
-                .vaultToken("test-token")
-                .retryBackoffMs(Duration.ZERO)
-                .build()
-        );
+        assertThatCode(() ->
+                VaultCryptoConfiguration
+                    .builder()
+                    .vaultUrl("https://vault.example.com")
+                    .vaultToken("test-token")
+                    .retryBackoffMs(Duration.ZERO)
+                    .build()
+            )
+            .doesNotThrowAnyException();
     }
 
     @Test
     @DisplayName("Should implement equals and hashCode correctly")
     void shouldImplementEqualsAndHashCodeCorrectly() {
-        VaultCryptoConfiguration config1 = VaultCryptoConfiguration
+        var config1 = VaultCryptoConfiguration
             .builder()
             .vaultUrl("https://vault.example.com")
             .vaultToken("test-token")
             .build();
 
-        VaultCryptoConfiguration config2 = VaultCryptoConfiguration
+        var config2 = VaultCryptoConfiguration
             .builder()
             .vaultUrl("https://vault.example.com")
             .vaultToken("test-token")
             .build();
 
-        VaultCryptoConfiguration config3 = VaultCryptoConfiguration
+        var config3 = VaultCryptoConfiguration
             .builder()
             .vaultUrl("https://different-vault.example.com")
             .vaultToken("test-token")
             .build();
 
-        assertEquals(config1, config2);
-        assertEquals(config1.hashCode(), config2.hashCode());
-        assertNotEquals(config1, config3);
-        assertNotEquals(config1.hashCode(), config3.hashCode());
+        assertThat(config1).isEqualTo(config2).hasSameHashCodeAs(config2);
+        assertThat(config1).isNotEqualTo(config3);
+        assertThat(config1.hashCode()).isNotEqualTo(config3.hashCode());
     }
 
     @Test
     @DisplayName("Should redact token in toString")
     void shouldRedactTokenInToString() {
-        VaultCryptoConfiguration config = VaultCryptoConfiguration
+        var config = VaultCryptoConfiguration
             .builder()
             .vaultUrl("https://vault.example.com")
             .vaultToken("secret-token")
             .build();
 
-        String toString = config.toString();
-        assertFalse(toString.contains("secret-token"));
-        assertTrue(toString.contains("[REDACTED]"));
-        assertTrue(toString.contains("https://vault.example.com"));
+        var toString = config.toString();
+        assertThat(toString)
+            .doesNotContain("secret-token")
+            .contains("[REDACTED]")
+            .contains("https://vault.example.com");
     }
 }

--- a/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultCryptoExceptionTest.java
+++ b/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultCryptoExceptionTest.java
@@ -3,45 +3,45 @@ package pi2schema.crypto.providers.vault;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class VaultCryptoExceptionTest {
 
     @Test
     @DisplayName("Should create exception with message")
     void shouldCreateExceptionWithMessage() {
-        String message = "Test error message";
-        VaultCryptoException exception = new VaultCryptoException(message);
+        var message = "Test error message";
+        var exception = new VaultCryptoException(message);
 
-        assertEquals(message, exception.getMessage());
-        assertNull(exception.getCause());
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getCause()).isNull();
     }
 
     @Test
     @DisplayName("Should create exception with message and cause")
     void shouldCreateExceptionWithMessageAndCause() {
-        String message = "Test error message";
-        Throwable cause = new RuntimeException("Root cause");
-        VaultCryptoException exception = new VaultCryptoException(message, cause);
+        var message = "Test error message";
+        var cause = new RuntimeException("Root cause");
+        var exception = new VaultCryptoException(message, cause);
 
-        assertEquals(message, exception.getMessage());
-        assertEquals(cause, exception.getCause());
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getCause()).isEqualTo(cause);
     }
 
     @Test
     @DisplayName("Should create exception with cause only")
     void shouldCreateExceptionWithCauseOnly() {
-        Throwable cause = new RuntimeException("Root cause");
-        VaultCryptoException exception = new VaultCryptoException(cause);
+        var cause = new RuntimeException("Root cause");
+        var exception = new VaultCryptoException(cause);
 
-        assertEquals(cause, exception.getCause());
-        assertTrue(exception.getMessage().contains("RuntimeException"));
+        assertThat(exception.getCause()).isEqualTo(cause);
+        assertThat(exception.getMessage()).contains("RuntimeException");
     }
 
     @Test
     @DisplayName("Should be instance of RuntimeException")
     void shouldBeInstanceOfRuntimeException() {
-        VaultCryptoException exception = new VaultCryptoException("Test message");
-        assertInstanceOf(RuntimeException.class, exception);
+        var exception = new VaultCryptoException("Test message");
+        assertThat(exception).isInstanceOf(RuntimeException.class);
     }
 }

--- a/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultErrorHandlingAndLoggingTest.java
+++ b/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultErrorHandlingAndLoggingTest.java
@@ -9,16 +9,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
-import pi2schema.crypto.providers.EncryptionMaterial;
 
 import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Comprehensive tests for error handling and logging in Vault crypto providers.
@@ -100,192 +97,134 @@ class VaultErrorHandlingAndLoggingTest {
     @DisplayName("Should log initialization without exposing sensitive data")
     void shouldLogInitializationWithoutSensitiveData() {
         // When
-        VaultEncryptingMaterialsProvider provider = new VaultEncryptingMaterialsProvider(validConfig);
+        try (var provider = new VaultEncryptingMaterialsProvider(validConfig)) {
+            // Then
+            var logEvents = logAppender.list;
 
-        // Then
-        List<ILoggingEvent> logEvents = logAppender.list;
-
-        // Verify initialization is logged
-        assertTrue(
-            logEvents
-                .stream()
+            // Verify initialization is logged
+            assertThat(logEvents)
                 .anyMatch(event ->
                     event.getLevel() == Level.INFO &&
                     event.getMessage().contains("VaultEncryptingMaterialsProvider initialized")
-                ),
-            "Should log provider initialization"
-        );
-
-        assertTrue(
-            logEvents
-                .stream()
+                );
+            assertThat(logEvents)
                 .anyMatch(event ->
                     event.getLevel() == Level.INFO && event.getMessage().contains("VaultTransitClient initialized")
-                ),
-            "Should log client initialization"
-        );
+                );
 
-        // Verify no sensitive data in logs
-        logEvents.forEach(event -> {
-            String message = event.getFormattedMessage();
-            assertFalse(message.contains("test-token-12345"), "Should not log vault token: " + message);
-            assertFalse(message.contains("password"), "Should not log passwords: " + message);
-        });
-
-        provider.close();
+            // Verify no sensitive data in logs
+            logEvents.forEach(event -> {
+                var message = event.getFormattedMessage();
+                assertThat(message).doesNotContain("test-token-12345", "password");
+            });
+        }
     }
 
     @Test
     @DisplayName("Should handle null subject ID with proper error logging")
     void shouldHandleNullSubjectIdWithProperErrorLogging() {
-        VaultEncryptingMaterialsProvider provider = new VaultEncryptingMaterialsProvider(validConfig);
+        try (var provider = new VaultEncryptingMaterialsProvider(validConfig)) {
+            // When
+            var future = provider.encryptionKeysFor(null);
 
-        // When
-        CompletableFuture<EncryptionMaterial> future = provider.encryptionKeysFor(null);
+            // Then
+            assertThatThrownBy(future::join)
+                .isInstanceOf(CompletionException.class)
+                .cause()
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Subject ID cannot be null or empty");
 
-        // Then
-        CompletionException exception = assertThrows(CompletionException.class, future::join);
+            // Verify error logging
+            var errorLogs = logAppender.list.stream().filter(event -> event.getLevel() == Level.ERROR).toList();
 
-        assertTrue(exception.getCause() instanceof IllegalArgumentException);
-        assertEquals("Subject ID cannot be null or empty", exception.getCause().getMessage());
-
-        // Verify error logging
-        List<ILoggingEvent> errorLogs = logAppender.list
-            .stream()
-            .filter(event -> event.getLevel() == Level.ERROR)
-            .toList();
-
-        assertTrue(
-            errorLogs.stream().anyMatch(event -> event.getMessage().contains("Encryption materials generation failed")),
-            "Should log null subject ID error"
-        );
-
-        provider.close();
+            assertThat(errorLogs)
+                .anyMatch(event -> event.getMessage().contains("Encryption materials generation failed"));
+        }
     }
 
     @Test
     @DisplayName("Should handle empty subject ID with proper error logging")
     void shouldHandleEmptySubjectIdWithProperErrorLogging() {
-        VaultEncryptingMaterialsProvider provider = new VaultEncryptingMaterialsProvider(validConfig);
+        try (var provider = new VaultEncryptingMaterialsProvider(validConfig)) {
+            // When
+            var future = provider.encryptionKeysFor("   ");
 
-        // When
-        CompletableFuture<EncryptionMaterial> future = provider.encryptionKeysFor("   ");
-
-        // Then
-        ExecutionException exception = assertThrows(
-            ExecutionException.class,
-            () -> {
-                future.get(1, TimeUnit.SECONDS);
-            }
-        );
-
-        assertTrue(exception.getCause() instanceof IllegalArgumentException);
-
-        provider.close();
+            // Then
+            assertThatThrownBy(() -> future.get(1, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class);
+        }
     }
 
     @Test
     @DisplayName("Should handle connectivity failures with proper error handling")
     void shouldHandleConnectivityFailuresWithProperErrorHandling() {
-        VaultEncryptingMaterialsProvider provider = new VaultEncryptingMaterialsProvider(invalidConfig);
+        try (var provider = new VaultEncryptingMaterialsProvider(invalidConfig)) {
+            // When
+            var future = provider.encryptionKeysFor("test-subject");
 
-        // When
-        CompletableFuture<EncryptionMaterial> future = provider.encryptionKeysFor("test-subject");
-
-        // Then
-        assertThrows(
-            ExecutionException.class,
-            () -> {
-                future.get(5, TimeUnit.SECONDS);
-            }
-        );
-
-        // Note: Retry behavior verification is now handled in
-        // VaultNetworkErrorHandlingTest
-        // using WireMock request counting instead of log-based verification.
-        // This test focuses on error handling and logging of other aspects.
-
-        provider.close();
+            // Then
+            assertThatThrownBy(() -> future.get(5, TimeUnit.SECONDS)).isInstanceOf(ExecutionException.class);
+            // Note: Retry behavior verification is now handled in
+            // VaultNetworkErrorHandlingTest
+            // using WireMock request counting instead of log-based verification.
+            // This test focuses on error handling and logging of other aspects.
+        }
     }
 
     @Test
     @DisplayName("Should handle invalid encryption context with detailed error logging")
     void shouldHandleInvalidEncryptionContextWithDetailedErrorLogging() {
-        VaultDecryptingMaterialsProvider provider = new VaultDecryptingMaterialsProvider(validConfig);
+        try (var provider = new VaultDecryptingMaterialsProvider(validConfig)) {
+            // When
+            var future = provider.decryptionKeysFor(
+                "test-subject",
+                "invalid-encrypted-key".getBytes(),
+                "invalid-context-format"
+            );
 
-        // When
-        CompletableFuture<com.google.crypto.tink.Aead> future = provider.decryptionKeysFor(
-            "test-subject",
-            "invalid-encrypted-key".getBytes(),
-            "invalid-context-format"
-        );
+            // Then
+            assertThatThrownBy(() -> future.get(1, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(InvalidEncryptionContextException.class);
 
-        // Then
-        ExecutionException exception = assertThrows(
-            ExecutionException.class,
-            () -> {
-                future.get(1, TimeUnit.SECONDS);
-            }
-        );
+            // Verify detailed error logging
+            var errorLogs = logAppender.list.stream().filter(event -> event.getLevel() == Level.ERROR).toList();
 
-        assertTrue(exception.getCause() instanceof InvalidEncryptionContextException);
-
-        // Verify detailed error logging
-        List<ILoggingEvent> errorLogs = logAppender.list
-            .stream()
-            .filter(event -> event.getLevel() == Level.ERROR)
-            .toList();
-
-        assertTrue(
-            errorLogs.stream().anyMatch(event -> event.getMessage().contains("Encryption context format is invalid")),
-            "Should log encryption context validation error"
-        );
-
-        provider.close();
+            assertThat(errorLogs)
+                .anyMatch(event -> event.getMessage().contains("Encryption context format is invalid"));
+        }
     }
 
     @Test
     @DisplayName("Should handle subject ID mismatch with clear error logging")
     void shouldHandleSubjectIdMismatchWithClearErrorLogging() {
-        VaultDecryptingMaterialsProvider provider = new VaultDecryptingMaterialsProvider(validConfig);
+        try (var provider = new VaultDecryptingMaterialsProvider(validConfig)) {
+            // When - context has different subject ID
+            var contextWithWrongSubject = "subjectId=wrong-subject;timestamp=1234567890;version=1.0";
+            var future = provider.decryptionKeysFor(
+                "test-subject",
+                "encrypted-key".getBytes(),
+                contextWithWrongSubject
+            );
 
-        // When - context has different subject ID
-        String contextWithWrongSubject = "subjectId=wrong-subject;timestamp=1234567890;version=1.0";
-        CompletableFuture<com.google.crypto.tink.Aead> future = provider.decryptionKeysFor(
-            "test-subject",
-            "encrypted-key".getBytes(),
-            contextWithWrongSubject
-        );
+            // Then
+            assertThatThrownBy(() -> future.get(1, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(InvalidEncryptionContextException.class);
 
-        // Then
-        ExecutionException exception = assertThrows(
-            ExecutionException.class,
-            () -> {
-                future.get(1, TimeUnit.SECONDS);
-            }
-        );
+            // Verify subject mismatch error logging
+            var errorLogs = logAppender.list.stream().filter(event -> event.getLevel() == Level.ERROR).toList();
 
-        assertTrue(exception.getCause() instanceof InvalidEncryptionContextException);
-
-        // Verify subject mismatch error logging
-        List<ILoggingEvent> errorLogs = logAppender.list
-            .stream()
-            .filter(event -> event.getLevel() == Level.ERROR)
-            .toList();
-
-        assertTrue(
-            errorLogs.stream().anyMatch(event -> event.getMessage().contains("Subject ID mismatch")),
-            "Should log subject ID mismatch error"
-        );
-
-        provider.close();
+            assertThat(errorLogs).anyMatch(event -> event.getMessage().contains("Subject ID mismatch"));
+        }
     }
 
     @Test
     @DisplayName("Should sanitize URLs in log messages")
     void shouldSanitizeUrlsInLogMessages() {
         // Create config with query parameters that should be sanitized
-        VaultCryptoConfiguration configWithQuery = VaultCryptoConfiguration
+        var configWithQuery = VaultCryptoConfiguration
             .builder()
             .vaultUrl("https://vault.example.com:8200?token=secret123&other=value")
             .vaultToken("test-token")
@@ -294,165 +233,121 @@ class VaultErrorHandlingAndLoggingTest {
             .build();
 
         // When
-        VaultEncryptingMaterialsProvider provider = new VaultEncryptingMaterialsProvider(configWithQuery);
+        try (var provider = new VaultEncryptingMaterialsProvider(configWithQuery)) {
+            // Then
+            var logEvents = logAppender.list;
 
-        // Then
-        List<ILoggingEvent> logEvents = logAppender.list;
-
-        // Verify URLs are sanitized
-        logEvents.forEach(event -> {
-            String message = event.getFormattedMessage();
-            if (message.contains("vault.example.com")) {
-                assertFalse(
-                    message.contains("token=secret123"),
-                    "Should sanitize sensitive query parameters: " + message
-                );
-                if (message.contains("?")) {
-                    assertTrue(
-                        message.contains("[REDACTED]"),
-                        "Should replace query parameters with [REDACTED]: " + message
-                    );
+            // Verify URLs are sanitized
+            logEvents.forEach(event -> {
+                var message = event.getFormattedMessage();
+                if (message.contains("vault.example.com")) {
+                    assertThat(message).doesNotContain("token=secret123");
+                    if (message.contains("?")) {
+                        assertThat(message).contains("[REDACTED]");
+                    }
                 }
-            }
-        });
-
-        provider.close();
+            });
+        }
     }
 
     @Test
     @DisplayName("Should log request IDs for correlation")
     void shouldLogRequestIdsForCorrelation() {
-        VaultEncryptingMaterialsProvider provider = new VaultEncryptingMaterialsProvider(invalidConfig);
+        try (var provider = new VaultEncryptingMaterialsProvider(invalidConfig)) {
+            // When - this will fail but should generate request IDs
+            var future = provider.encryptionKeysFor("test-subject");
 
-        // When - this will fail but should generate request IDs
-        CompletableFuture<EncryptionMaterial> future = provider.encryptionKeysFor("test-subject");
+            assertThatThrownBy(() -> future.get(3, TimeUnit.SECONDS)).isInstanceOf(ExecutionException.class);
 
-        assertThrows(
-            ExecutionException.class,
-            () -> {
-                future.get(3, TimeUnit.SECONDS);
-            }
-        );
+            // Then
+            var debugLogs = logAppender.list.stream().filter(event -> event.getLevel() == Level.DEBUG).toList();
 
-        // Then
-        List<ILoggingEvent> debugLogs = logAppender.list
-            .stream()
-            .filter(event -> event.getLevel() == Level.DEBUG)
-            .toList();
-
-        // Verify request IDs are present in logs
-        assertTrue(
-            debugLogs.stream().anyMatch(event -> event.getMessage().contains("requestId=")),
-            "Should include request IDs in debug logs"
-        );
-
-        provider.close();
+            // Verify request IDs are present in logs
+            assertThat(debugLogs).anyMatch(event -> event.getMessage().contains("requestId="));
+        }
     }
 
     @Test
     @DisplayName("Should handle configuration validation errors with clear messages")
     void shouldHandleConfigurationValidationErrorsWithClearMessages() {
         // When - invalid URL format
-        IllegalArgumentException exception1 = assertThrows(
-            IllegalArgumentException.class,
-            () -> {
-                VaultCryptoConfiguration.builder().vaultUrl("invalid-url-format").vaultToken("token").build();
-            }
-        );
-
-        assertTrue(exception1.getMessage().contains("Vault URL must start with http:// or https://"));
+        assertThatThrownBy(() ->
+                VaultCryptoConfiguration.builder().vaultUrl("invalid-url-format").vaultToken("token").build()
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Vault URL must start with http:// or https://");
 
         // When - invalid key prefix
-        IllegalArgumentException exception2 = assertThrows(
-            IllegalArgumentException.class,
-            () ->
+        assertThatThrownBy(() ->
                 VaultCryptoConfiguration
                     .builder()
                     .vaultUrl("https://vault.example.com")
                     .vaultToken("token")
                     .keyPrefix("invalid@prefix")
                     .build()
-        );
-
-        assertTrue(exception2.getMessage().contains("Key prefix can only contain alphanumeric characters"));
+            )
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Key prefix can only contain alphanumeric characters");
     }
 
     @Test
     @DisplayName("Should not log sensitive data in exception messages")
     void shouldNotLogSensitiveDataInExceptionMessages() {
-        VaultEncryptingMaterialsProvider provider = new VaultEncryptingMaterialsProvider(invalidConfig);
+        try (var provider = new VaultEncryptingMaterialsProvider(invalidConfig)) {
+            // When
+            var future = provider.encryptionKeysFor("test-subject");
 
-        // When
-        CompletableFuture<EncryptionMaterial> future = provider.encryptionKeysFor("test-subject");
+            assertThatThrownBy(future::join).isInstanceOf(CompletionException.class);
 
-        assertThrows(CompletionException.class, future::join);
+            // Then - verify no sensitive data in any log messages
+            var allLogs = logAppender.list;
 
-        // Then - verify no sensitive data in any log messages
-        List<ILoggingEvent> allLogs = logAppender.list;
+            allLogs.forEach(event -> {
+                var message = event.getFormattedMessage();
 
-        allLogs.forEach(event -> {
-            String message = event.getFormattedMessage();
+                // Should not contain tokens
+                assertThat(message).doesNotContain("invalid-token");
 
-            // Should not contain tokens
-            assertFalse(message.contains("invalid-token"), "Should not log vault token: " + message);
+                // Should not contain raw key material
+                assertThat(message).doesNotMatch(".*\\b[A-Za-z0-9+/]{40,}={0,2}\\b.*");
 
-            // Should not contain raw key material (check for base64-like patterns that look
-            // like keys)
-            assertFalse(
-                message.matches(".*\\b[A-Za-z0-9+/]{40,}={0,2}\\b.*"),
-                "Should not log base64 key material: " + message
-            );
-
-            // Should not contain actual plaintext data (but references to "plaintext" in
-            // error messages are OK)
-            assertFalse(
-                message.matches(".*plaintext[\\s]*[:=][\\s]*[A-Za-z0-9+/=]{8,}.*"),
-                "Should not log actual plaintext data: " + message
-            );
-        });
-
-        provider.close();
+                // Should not contain actual plaintext data
+                assertThat(message).doesNotMatch(".*plaintext[\\s]*[:=][\\s]*[A-Za-z0-9+/=]{8,}.*");
+            });
+        }
     }
 
     @Test
     @DisplayName("Should provide meaningful error messages for different failure scenarios")
     void shouldProvideMeaningfulErrorMessagesForDifferentFailureScenarios() {
-        VaultDecryptingMaterialsProvider provider = new VaultDecryptingMaterialsProvider(validConfig);
+        try (var provider = new VaultDecryptingMaterialsProvider(validConfig)) {
+            // Test 1: Null encrypted data key
+            assertThatThrownBy(() ->
+                    provider.decryptionKeysFor("test-subject", null, "valid-context").get(1, TimeUnit.SECONDS)
+                )
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .hasMessageContaining("Encrypted data key cannot be null")
+                .hasMessageContaining("subjectId=test-subject");
 
-        // Test 1: Null encrypted data key
-        ExecutionException exception1 = assertThrows(
-            ExecutionException.class,
-            () -> {
-                provider.decryptionKeysFor("test-subject", null, "valid-context").get(1, TimeUnit.SECONDS);
-            }
-        );
+            // Test 2: Empty encrypted data key
+            assertThatThrownBy(() ->
+                    provider.decryptionKeysFor("test-subject", new byte[0], "valid-context").get(1, TimeUnit.SECONDS)
+                )
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .hasMessageContaining("Encrypted data key cannot be null or empty");
 
-        assertTrue(exception1.getCause().getMessage().contains("Encrypted data key cannot be null"));
-        assertTrue(exception1.getCause().getMessage().contains("subjectId=test-subject"));
-
-        // Test 2: Empty encrypted data key
-        ExecutionException exception2 = assertThrows(
-            ExecutionException.class,
-            () -> {
-                provider.decryptionKeysFor("test-subject", new byte[0], "valid-context").get(1, TimeUnit.SECONDS);
-            }
-        );
-
-        assertTrue(exception2.getCause().getMessage().contains("Encrypted data key cannot be null or empty"));
-
-        // Test 3: Invalid timestamp in context
-        String invalidTimestampContext = "subjectId=test-subject;timestamp=invalid;version=1.0";
-        ExecutionException exception3 = assertThrows(
-            ExecutionException.class,
-            () -> {
-                provider
-                    .decryptionKeysFor("test-subject", "key".getBytes(), invalidTimestampContext)
-                    .get(1, TimeUnit.SECONDS);
-            }
-        );
-
-        assertTrue(exception3.getCause().getMessage().contains("Invalid timestamp format"));
-
-        provider.close();
+            // Test 3: Invalid timestamp in context
+            var invalidTimestampContext = "subjectId=test-subject;timestamp=invalid;version=1.0";
+            assertThatThrownBy(() ->
+                    provider
+                        .decryptionKeysFor("test-subject", "key".getBytes(), invalidTimestampContext)
+                        .get(1, TimeUnit.SECONDS)
+                )
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .hasMessageContaining("Invalid timestamp format");
+        }
     }
 }

--- a/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultTransitClientGdprTest.java
+++ b/crypto-providers-vault/src/test/java/pi2schema/crypto/providers/vault/VaultTransitClientGdprTest.java
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for GDPR compliance methods in VaultTransitClient.
@@ -37,87 +38,57 @@ class VaultTransitClientGdprTest {
 
     @Test
     void testGenerateKeyName() {
-        String subjectId = "user-123";
-        String expectedKeyName = "test-prefix_subject_user-123";
+        var subjectId = "user-123";
+        var expectedKeyName = "test-prefix_subject_user-123";
 
-        String actualKeyName = transitClient.generateKeyName(subjectId);
-        assertEquals(expectedKeyName, actualKeyName);
+        var actualKeyName = transitClient.generateKeyName(subjectId);
+        assertThat(actualKeyName).isEqualTo(expectedKeyName);
     }
 
     @Test
     void testGenerateKeyNameWithSpecialCharacters() {
-        String subjectId = "user@domain.com";
-        String expectedKeyName = "test-prefix_subject_user_domain_com";
+        var subjectId = "user@domain.com";
+        var expectedKeyName = "test-prefix_subject_user_domain_com";
 
-        String actualKeyName = transitClient.generateKeyName(subjectId);
-        assertEquals(expectedKeyName, actualKeyName);
+        var actualKeyName = transitClient.generateKeyName(subjectId);
+        assertThat(actualKeyName).isEqualTo(expectedKeyName);
     }
 
     @Test
     void testGenerateKeyNameWithNullSubjectId() {
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> {
-                transitClient.generateKeyName(null);
-            }
-        );
+        assertThatThrownBy(() -> transitClient.generateKeyName(null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void testGenerateKeyNameWithEmptySubjectId() {
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> {
-                transitClient.generateKeyName("");
-            }
-        );
+        assertThatThrownBy(() -> transitClient.generateKeyName("")).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void testSubjectKeyExistsWithNullSubjectId() {
-        ExecutionException exception = assertThrows(
-            ExecutionException.class,
-            () -> {
-                transitClient.subjectKeyExists(null).get();
-            }
-        );
-
-        assertTrue(exception.getCause() instanceof IllegalArgumentException);
+        assertThatThrownBy(() -> transitClient.subjectKeyExists(null).get())
+            .isInstanceOf(ExecutionException.class)
+            .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void testSubjectKeyExistsWithEmptySubjectId() {
-        ExecutionException exception = assertThrows(
-            ExecutionException.class,
-            () -> {
-                transitClient.subjectKeyExists("").get();
-            }
-        );
-
-        assertTrue(exception.getCause() instanceof IllegalArgumentException);
+        assertThatThrownBy(() -> transitClient.subjectKeyExists("").get())
+            .isInstanceOf(ExecutionException.class)
+            .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void testDeleteSubjectKeyWithNullSubjectId() {
-        ExecutionException exception = assertThrows(
-            ExecutionException.class,
-            () -> {
-                transitClient.deleteSubjectKey(null).get();
-            }
-        );
-
-        assertTrue(exception.getCause() instanceof IllegalArgumentException);
+        assertThatThrownBy(() -> transitClient.deleteSubjectKey(null).get())
+            .isInstanceOf(ExecutionException.class)
+            .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void testDeleteSubjectKeyWithEmptySubjectId() {
-        ExecutionException exception = assertThrows(
-            ExecutionException.class,
-            () -> {
-                transitClient.deleteSubjectKey("").get();
-            }
-        );
-
-        assertTrue(exception.getCause() instanceof IllegalArgumentException);
+        assertThatThrownBy(() -> transitClient.deleteSubjectKey("").get())
+            .isInstanceOf(ExecutionException.class)
+            .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
+}
+
 rootProject.name = 'pi2schema'
 
 dependencyResolutionManagement {


### PR DESCRIPTION
This commit refactors all test cases in the `crypto-providers-vault` module to use AssertJ for assertions instead of JUnit's Hamcrest assertions. This aligns the module with the assertion style used across the rest of the project.

Additionally, local variable declarations have been updated to use the `var` keyword where possible, improving code readability and conciseness.

A `foojay-resolver-convention` plugin was also added to the `settings.gradle` file to enable automatic JDK toolchain provisioning, which resolves build issues in environments where the required JDK is not pre-installed.